### PR TITLE
fix: correct Jules action reference

### DIFF
--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Invoke Jules
         if: ${{ contains(fromJSON('["srMarlins"]'), github.event.issue.user.login) }}
-        uses: google-labs-code/jules-invoke@v1
+        uses: google-labs-code/jules-action@v1
         with:
           prompt: |
             Fix the following GitHub issue for the ChromaDMX project.


### PR DESCRIPTION
## Summary
- Fix Jules GitHub Action reference from `google-labs-code/jules-invoke@v1` to `google-labs-code/jules-action@v1`
- The `jules-invoke` repo doesn't have a `v1` tag; `jules-action` does (`v1.0.0`)

## Test plan
- [ ] Re-trigger Jules label on an issue after merge and verify workflow resolves the action