### PR TITLE
feat: add Claude auto-review for Jules PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,54 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    if: github.event.pull_request.user.login == 'jules-google[bot]' || github.event.pull_request.user.login == 'jules[bot]' || contains(github.event.pull_request.labels.*.name, 'claude-review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR TITLE: ${{ github.event.pull_request.title }}
+
+            This PR was created by an AI coding agent (Jules). Review it thoroughly and fix any issues.
+
+            ## Review checklist:
+            1. Read the linked issue to understand requirements
+            2. Review all changed files for correctness
+            3. Verify it follows project conventions:
+               - Kotlin Multiplatform shared code in shared/, platform code in android/ and ios/
+               - Compose Multiplatform for UI
+               - Koin for dependency injection
+               - StateFlow for observable state
+               - kotlinx.serialization for data models
+            4. Check for:
+               - Missing or incorrect tests
+               - Code that doesn't compile or has obvious bugs
+               - Security issues
+               - Missing Koin module registrations
+               - Incorrect package names (should be com.chromadmx.*)
+            5. If you find issues, fix them directly by pushing commits to the PR branch
+            6. If the PR looks good, approve it with a comment summarizing what was reviewed
+            7. Post inline comments for anything noteworthy
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            If fixes are needed, make the changes and commit them directly to the PR branch.


### PR DESCRIPTION
## Summary
- Adds workflow that triggers Claude Code Action on PRs from Jules
- Claude reviews for project conventions, correctness, and security
- Pushes fixes directly to the PR branch if issues found
- Also triggerable via `claude-review` label on any PR

## Setup required
- Add `ANTHROPIC_API_KEY` repo secret (Settings → Secrets → Actions)

## Test plan
- [ ] Merge this PR, then check if Claude reviews the pending Jules PRs