### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix potential memory DoS in NodeDiscovery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Memory DoS in NodeDiscovery
+**Vulnerability:** NodeDiscovery stored unlimited DMX nodes based on spoofable nodeKey (IP/MAC).
+**Learning:** UDP-based discovery protocols are vulnerable to spoofing, leading to unbounded memory usage if not capped.
+**Prevention:** Always enforce a hard limit (maxNodes) on network-populated collections and use an eviction policy (e.g., oldest seen) to handle overflow.


### PR DESCRIPTION
Added `maxNodes` limit (default 256) and an eviction policy (oldest seen) to `NodeDiscovery` to prevent memory exhaustion from spoofed ArtNet replies. This addresses a potential Denial of Service vulnerability where an attacker could flood the discovery service with fake nodes.

- Added `maxNodes` parameter to `NodeDiscovery` constructor.
- Implemented eviction logic in `processReply`.
- Added `processReply_maxNodesReached_evictsOldest` test case.
- Documented the vulnerability in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2854488197557386884](https://jules.google.com/task/2854488197557386884) started by @srMarlins*