### PR TITLE
🎨 Palette: Improve PixelButton accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Custom Clickable Components
+**Learning:** Using `clickable(indication = null)` completely removes focus feedback. In `PixelButton`, this meant keyboard users had no way to know where focus was.
+**Action:** Always add manual focus handling (border color change, scale, etc.) when disabling standard indication. Use `interactionSource.collectIsFocusedAsState()`.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -18,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -34,29 +36,41 @@ fun PixelButton(
     borderColor: Color = Color.White,
     pixelSize: Dp = LocalPixelTheme.current.pixelSize,
     contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+    enabled: Boolean = true,
+    role: Role? = Role.Button,
+    onClickLabel: String? = null,
     content: @Composable () -> Unit
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
+    val isFocused by interactionSource.collectIsFocusedAsState()
 
     val pressedOffset by animateFloatAsState(if (isPressed) 4f else 0f)
+
+    // Visual adjustments for state
+    val finalBackgroundColor = if (enabled) backgroundColor else backgroundColor.copy(alpha = 0.5f)
+    val finalBorderColor = if (isFocused) MaterialTheme.colorScheme.secondary else borderColor
+    val finalContentColor = if (enabled) contentColor else contentColor.copy(alpha = 0.5f)
 
     Box(
         modifier = modifier
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
+                enabled = enabled,
+                onClickLabel = onClickLabel,
+                role = role,
                 onClick = onClick
             )
-            .pixelBorder(color = borderColor, pixelSize = pixelSize)
-            .background(backgroundColor.copy(alpha = 0.5f)) // Background behind the border
+            .pixelBorder(color = finalBorderColor, pixelSize = pixelSize)
+            .background(finalBackgroundColor.copy(alpha = 0.5f)) // Background behind the border
             .padding(pixelSize) // Padding for the border width
             .offset { IntOffset(0, pressedOffset.roundToInt()) }
-            .background(backgroundColor)
+            .background(finalBackgroundColor)
             .padding(contentPadding),
         contentAlignment = Alignment.Center
     ) {
-        ProvideTextStyle(MaterialTheme.typography.labelLarge.copy(color = contentColor, fontFamily = PixelFontFamily)) {
+        ProvideTextStyle(MaterialTheme.typography.labelLarge.copy(color = finalContentColor, fontFamily = PixelFontFamily)) {
             content()
         }
     }


### PR DESCRIPTION
Improved the `PixelButton` component to be more accessible and interactive.

**Changes:**
1.  **Accessibility:**
    *   Added `role = Role.Button` by default.
    *   Added `onClickLabel` support for screen readers.
    *   Added `enabled` state support, visually dimming the button when disabled.
2.  **Interactivity:**
    *   Added focus indication! `PixelButton` now changes its border color to `secondary` when focused, fixing a major issue where keyboard users couldn't see the active button.
3.  **Refactoring:**
    *   Added new parameters (`enabled`, `role`, `onClickLabel`) to the *end* of the parameter list to maintain backward compatibility for positional arguments.

**Verification:**
*   Verified code logic by reading.
*   Compilation fails due to unrelated errors in `PerformViewModel` (missing `SceneStore`), but `PixelButton` changes are isolated and use standard Compose APIs.
*   Verified no new errors were introduced related to `PixelButton`.

---
*PR created automatically by Jules for task [8776975332701460387](https://jules.google.com/task/8776975332701460387) started by @srMarlins*