### PR TITLE
fix: replace deleted SceneStore with PresetLibrary

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/di/UiModule.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/di/UiModule.kt
@@ -35,7 +35,7 @@ val uiModule = module {
         PerformViewModel(
             engine = get(),
             effectRegistry = get(),
-            sceneStore = get(),
+            presetLibrary = get(),
             beatClock = get(),
             scope = vmScope,
         )


### PR DESCRIPTION
## Summary
- PR #35 deleted `SceneStore.kt` but left references in `PerformViewModel` and `UiModule`, breaking compilation on main since commit `ed7aead`
- Replaces all `SceneStore` usage with `PresetLibrary` from `engine.preset` package
- Adds `ScenePreset.toScene()` conversion for backward compat with UI composables

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata` passes
- [ ] CI build-and-test passes