### PR TITLE
feat: add beat visualization & BPM display

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BarPhaseIndicator.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BarPhaseIndicator.kt
@@ -1,0 +1,68 @@
+package com.chromadmx.ui.components.beat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.chromadmx.ui.components.pixelBorder
+import com.chromadmx.ui.theme.BeatActive
+import com.chromadmx.ui.theme.BeatInactive
+import com.chromadmx.ui.theme.LocalPixelTheme
+
+/**
+ * Four pixel segments representing beats within a bar.
+ *
+ * The current beat segment lights up based on [barPhase]:
+ * - 0.00..0.25 = beat 1
+ * - 0.25..0.50 = beat 2
+ * - 0.50..0.75 = beat 3
+ * - 0.75..1.00 = beat 4
+ *
+ * @param barPhase      Phase within the current bar (0.0 to 1.0).
+ * @param modifier      Compose modifier.
+ * @param activeColor   Color for the currently active beat segment.
+ * @param inactiveColor Color for inactive beat segments.
+ * @param beatsPerBar   Number of beats per bar (default 4).
+ * @param pixelSize     Pixel unit for the border.
+ */
+@Composable
+fun BarPhaseIndicator(
+    barPhase: Float,
+    modifier: Modifier = Modifier,
+    activeColor: Color = BeatActive,
+    inactiveColor: Color = BeatInactive,
+    beatsPerBar: Int = 4,
+    pixelSize: Dp = LocalPixelTheme.current.pixelSize,
+) {
+    val currentBeat = (barPhase * beatsPerBar).toInt().coerceIn(0, beatsPerBar - 1)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(pixelSize * 4),
+        horizontalArrangement = Arrangement.spacedBy(pixelSize),
+    ) {
+        for (i in 0 until beatsPerBar) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .pixelBorder(
+                        color = if (i == currentBeat) activeColor.copy(alpha = 0.6f) else inactiveColor.copy(alpha = 0.3f),
+                        pixelSize = pixelSize,
+                    )
+                    .background(if (i == currentBeat) activeColor else inactiveColor)
+                    .padding(pixelSize),
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BeatBar.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BeatBar.kt
@@ -1,0 +1,65 @@
+package com.chromadmx.ui.components.beat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.chromadmx.core.model.BeatState
+
+/**
+ * Container composable combining [BpmDisplay], [BeatPhaseIndicator], and [BarPhaseIndicator].
+ *
+ * Layout: BPM display on the left (tappable for tap-tempo), beat phase bar and
+ * bar phase segments stacked on the right.
+ *
+ * @param beatState   Current [BeatState] snapshot from the tempo module.
+ * @param onTapTempo  Called when the user taps the BPM display for tap-tempo input.
+ * @param bpmSource   Indicates the source of the BPM (link, tap, idle) for color coding.
+ * @param modifier    Compose modifier.
+ */
+@Composable
+fun BeatBar(
+    beatState: BeatState,
+    onTapTempo: () -> Unit,
+    bpmSource: BpmSource = BpmSource.TAP,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // Left: BPM display (tappable)
+        BpmDisplay(
+            bpm = beatState.bpm,
+            beatPhase = beatState.beatPhase,
+            source = bpmSource,
+            onTap = onTapTempo,
+            modifier = Modifier.width(140.dp),
+        )
+
+        // Right: stacked indicators
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            // Beat phase progress bar
+            BeatPhaseIndicator(
+                beatPhase = beatState.beatPhase,
+            )
+
+            // Bar phase: 4-segment beat counter
+            BarPhaseIndicator(
+                barPhase = beatState.barPhase,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BeatPhaseIndicator.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BeatPhaseIndicator.kt
@@ -1,0 +1,70 @@
+package com.chromadmx.ui.components.beat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.chromadmx.ui.components.pixelBorder
+import com.chromadmx.ui.theme.BeatActive
+import com.chromadmx.ui.theme.BeatInactive
+import com.chromadmx.ui.theme.LocalPixelTheme
+
+/**
+ * A horizontal pixel bar showing beat phase progress (0.0 to 1.0).
+ *
+ * Divided into [segments] equal segments. Segments up to the current phase
+ * are filled with [activeColor]; the rest use [inactiveColor].
+ * The smooth phase value from the BeatClock drives the fill level each frame.
+ *
+ * @param beatPhase    Current beat phase (0.0 = downbeat, 1.0 = next downbeat).
+ * @param modifier     Compose modifier.
+ * @param activeColor  Color for filled segments.
+ * @param inactiveColor Color for unfilled segments.
+ * @param segments     Number of segments in the bar.
+ * @param pixelSize    Pixel unit for the border.
+ */
+@Composable
+fun BeatPhaseIndicator(
+    beatPhase: Float,
+    modifier: Modifier = Modifier,
+    activeColor: Color = BeatActive,
+    inactiveColor: Color = BeatInactive,
+    segments: Int = 16,
+    pixelSize: Dp = LocalPixelTheme.current.pixelSize,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(pixelSize * 3)
+            .pixelBorder(color = activeColor.copy(alpha = 0.3f), pixelSize = pixelSize)
+            .background(inactiveColor)
+            .padding(pixelSize),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(1.dp),
+        ) {
+            val activeSegments = (beatPhase * segments).toInt().coerceIn(0, segments)
+            for (i in 0 until segments) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .background(
+                            if (i < activeSegments) activeColor else Color.Transparent
+                        ),
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
@@ -1,0 +1,102 @@
+package com.chromadmx.ui.components.beat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.chromadmx.ui.components.pixelBorder
+import com.chromadmx.ui.theme.BeatActive
+import com.chromadmx.ui.theme.DmxSurface
+import com.chromadmx.ui.theme.LocalPixelTheme
+import com.chromadmx.ui.theme.NeonGreen
+import com.chromadmx.ui.theme.NeonYellow
+import com.chromadmx.ui.theme.NodeUnknown
+import com.chromadmx.ui.theme.PixelFontFamily
+
+/**
+ * Source of the BPM value, used to determine the display color.
+ */
+enum class BpmSource {
+    /** Synced via Ableton Link — shows NeonGreen. */
+    LINK,
+    /** Derived from tap tempo — shows NeonYellow. */
+    TAP,
+    /** No active source / idle — shows gray. */
+    IDLE
+}
+
+/**
+ * Displays the current BPM as large pixel-font text.
+ *
+ * Pulses opacity from 1.0 to 0.6 on each beat downbeat, driven by [beatPhase].
+ * Tap anywhere on the component to register a tap-tempo hit via [onTap].
+ *
+ * @param bpm        Current beats-per-minute value.
+ * @param beatPhase  Phase within the current beat (0.0 = downbeat, 1.0 = next downbeat).
+ * @param source     Where the BPM value originates (determines display color).
+ * @param onTap      Called when the user taps this display (for tap-tempo).
+ * @param modifier   Compose modifier.
+ * @param pixelSize  Pixel unit for the border.
+ */
+@Composable
+fun BpmDisplay(
+    bpm: Float,
+    beatPhase: Float,
+    source: BpmSource = BpmSource.TAP,
+    onTap: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    pixelSize: Dp = LocalPixelTheme.current.pixelSize,
+) {
+    val bpmColor: Color = when (source) {
+        BpmSource.LINK -> NeonGreen
+        BpmSource.TAP -> NeonYellow
+        BpmSource.IDLE -> NodeUnknown
+    }
+
+    // Pulse: opacity is 1.0 at the downbeat (phase=0), fades to 0.6 by mid-beat,
+    // then returns toward 1.0. Using a simple ease: alpha = 1 - 0.4 * (1 - phase)^2
+    // when phase < 0.3 (the "flash" zone), else 0.6 + 0.4 * ((phase - 0.3) / 0.7)
+    // Simpler approach: short flash near 0, then dim.
+    val pulseAlpha = if (beatPhase < 0.15f) {
+        // Flash zone: bright at 0, ramp down to 0.6 by 0.15
+        1.0f - (beatPhase / 0.15f) * 0.4f
+    } else {
+        // Sustain dim, slowly rise back
+        0.6f + (beatPhase - 0.15f) / 0.85f * 0.4f
+    }
+
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onTap,
+            )
+            .pixelBorder(color = bpmColor.copy(alpha = 0.5f), pixelSize = pixelSize)
+            .background(DmxSurface)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "${bpm.toInt()} BPM",
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = PixelFontFamily,
+                color = bpmColor,
+            ),
+            modifier = Modifier.alpha(pulseAlpha),
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/StagePreviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/StagePreviewScreen.kt
@@ -2,6 +2,7 @@ package com.chromadmx.ui.screen.stage
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.components.VenueCanvas
+import com.chromadmx.ui.components.beat.BeatBar
 import com.chromadmx.ui.viewmodel.StageViewModel
 
 /**
@@ -34,7 +36,7 @@ fun StagePreviewScreen(
     modifier: Modifier = Modifier,
 ) {
     val fixtures by viewModel.fixtures.collectAsState()
-    val bpm by viewModel.bpm.collectAsState()
+    val beatState by viewModel.beatState.collectAsState()
     val masterDimmer by viewModel.masterDimmer.collectAsState()
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -45,24 +47,29 @@ fun StagePreviewScreen(
             modifier = Modifier.fillMaxSize()
         )
 
-        // Top bar
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+        // Top bar: beat visualization + settings
+        Column(
+            modifier = Modifier.fillMaxWidth().align(Alignment.TopStart),
         ) {
-            Text(
-                text = "${bpm.toInt()} BPM",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary,
-            )
-
-            IconButton(onClick = onSettingsClick) {
-                Icon(
-                    imageVector = Icons.Default.Settings,
-                    contentDescription = "Settings",
-                    tint = MaterialTheme.colorScheme.onSurface,
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = 8.dp, top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Beat bar with BPM, phase indicators (takes most of the width)
+                BeatBar(
+                    beatState = beatState,
+                    onTapTempo = { viewModel.tap() },
+                    modifier = Modifier.weight(1f),
                 )
+
+                IconButton(onClick = onSettingsClick) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = "Settings",
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Add four new beat-reactive UI composables: `BpmDisplay`, `BeatPhaseIndicator`, `BarPhaseIndicator`, and `BeatBar`
- `BpmDisplay` shows BPM as large pixel-font text with beat-synced opacity pulse, tappable for tap-tempo, color-coded by source (Link green, Tap yellow, Idle gray)
- `BeatPhaseIndicator` is a 16-segment horizontal bar showing continuous beat phase progress (0.0-1.0)
- `BarPhaseIndicator` is a 4-segment display showing which beat in the bar is currently active
- `BeatBar` combines all three into a single horizontal layout container
- Wire `BeatBar` into `StagePreviewScreen` top bar, replacing the plain BPM text

Fixes #26

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata` passes
- [ ] Visual verification on Android emulator: BPM display pulses on beat, phase bar fills smoothly, bar segments light up in sequence
- [ ] Tap-tempo works when tapping the BPM display