### PR TITLE
feat(core): add SettingsRepository with multiplatform-settings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ koog = "0.6.3"
 # SQLDelight
 sqldelight = "2.0.2"
 
+# Multiplatform Settings
+multiplatform-settings = "1.3.0"
+
 # Testing
 kotlin-test = "2.3.10"
 
@@ -92,6 +95,11 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+
+# Multiplatform Settings
+multiplatform-settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
+multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
+multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatform-settings" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -15,6 +15,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.sqldelight.coroutines)
+            implementation(libs.multiplatform.settings.no.arg)
+            implementation(libs.multiplatform.settings.coroutines)
         }
         androidMain.dependencies {
             implementation(libs.sqldelight.android.driver)
@@ -25,6 +27,8 @@ kotlin {
         val androidHostTest by getting
         androidHostTest.dependencies {
             implementation(libs.sqldelight.sqlite.driver)
+            implementation(libs.multiplatform.settings.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/shared/core/src/androidHostTest/kotlin/com/chromadmx/core/persistence/SettingsRepositoryTest.kt
+++ b/shared/core/src/androidHostTest/kotlin/com/chromadmx/core/persistence/SettingsRepositoryTest.kt
@@ -1,0 +1,55 @@
+package com.chromadmx.core.persistence
+
+import com.russhwolf.settings.MapSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryTest {
+
+    private val settings = MapSettings()
+    private val repository = SettingsRepository(settings)
+
+    @Test
+    fun testMasterDimmer() = runTest {
+        assertEquals(1.0f, repository.masterDimmer.first())
+        repository.setMasterDimmer(0.5f)
+        assertEquals(0.5f, repository.masterDimmer.first())
+    }
+
+    @Test
+    fun testIsSimulation() = runTest {
+        assertFalse(repository.isSimulation.first())
+        repository.setSimulation(true)
+        assertTrue(repository.isSimulation.first())
+    }
+
+    @Test
+    fun testActivePresetId() = runTest {
+        assertNull(repository.activePresetId.first())
+        repository.setActivePresetId("preset-123")
+        assertEquals("preset-123", repository.activePresetId.first())
+        repository.setActivePresetId(null)
+        assertNull(repository.activePresetId.first())
+    }
+
+    @Test
+    fun testThemePreference() = runTest {
+        assertEquals("Dark", repository.themePreference.first())
+        repository.setThemePreference("Neon")
+        assertEquals("Neon", repository.themePreference.first())
+    }
+
+    @Test
+    fun testTransportMode() = runTest {
+        assertEquals("Real", repository.transportMode.first())
+        repository.setTransportMode("Simulated")
+        assertEquals("Simulated", repository.transportMode.first())
+    }
+}

--- a/shared/core/src/commonMain/kotlin/com/chromadmx/core/persistence/SettingsRepository.kt
+++ b/shared/core/src/commonMain/kotlin/com/chromadmx/core/persistence/SettingsRepository.kt
@@ -1,0 +1,55 @@
+package com.chromadmx.core.persistence
+
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.coroutines.toFlowSettings
+import com.russhwolf.settings.get
+import com.russhwolf.settings.set
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository for application-wide settings and preferences.
+ * Uses multiplatform-settings for cross-platform key-value storage.
+ */
+@OptIn(ExperimentalSettingsApi::class)
+class SettingsRepository(private val observableSettings: ObservableSettings) {
+    private val flowSettings = observableSettings.toFlowSettings()
+
+    val masterDimmer: Flow<Float> = flowSettings.getFloatFlow(KEY_MASTER_DIMMER, 1.0f)
+    val isSimulation: Flow<Boolean> = flowSettings.getBooleanFlow(KEY_IS_SIMULATION, false)
+    val activePresetId: Flow<String?> = flowSettings.getStringOrNullFlow(KEY_ACTIVE_PRESET_ID)
+    val themePreference: Flow<String> = flowSettings.getStringFlow(KEY_THEME_PREFERENCE, "Dark")
+    val transportMode: Flow<String> = flowSettings.getStringFlow(KEY_TRANSPORT_MODE, "Real")
+
+    fun setMasterDimmer(value: Float) {
+        observableSettings[KEY_MASTER_DIMMER] = value
+    }
+
+    fun setSimulation(enabled: Boolean) {
+        observableSettings[KEY_IS_SIMULATION] = enabled
+    }
+
+    fun setActivePresetId(id: String?) {
+        if (id == null) {
+            observableSettings.remove(KEY_ACTIVE_PRESET_ID)
+        } else {
+            observableSettings[KEY_ACTIVE_PRESET_ID] = id
+        }
+    }
+
+    fun setThemePreference(theme: String) {
+        observableSettings[KEY_THEME_PREFERENCE] = theme
+    }
+
+    fun setTransportMode(mode: String) {
+        observableSettings[KEY_TRANSPORT_MODE] = mode
+    }
+
+    companion object {
+        private const val KEY_MASTER_DIMMER = "master_dimmer"
+        private const val KEY_IS_SIMULATION = "is_simulation"
+        private const val KEY_ACTIVE_PRESET_ID = "active_preset_id"
+        private const val KEY_THEME_PREFERENCE = "theme_preference"
+        private const val KEY_TRANSPORT_MODE = "transport_mode"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
@@ -6,6 +6,7 @@ import com.chromadmx.core.model.Fixture3D
 import com.chromadmx.core.persistence.FixtureRepository
 import com.chromadmx.core.persistence.NetworkStateRepository
 import com.chromadmx.core.persistence.PresetRepository
+import com.chromadmx.core.persistence.SettingsRepository
 import com.chromadmx.engine.bridge.DmxBridge
 import com.chromadmx.engine.bridge.DmxOutputBridge
 import com.chromadmx.engine.effect.EffectRegistry
@@ -26,6 +27,8 @@ import com.chromadmx.networking.output.DmxOutputService
 import com.chromadmx.networking.transport.PlatformUdpTransport
 import com.chromadmx.tempo.clock.BeatClock
 import com.chromadmx.tempo.tap.TapTempoClock
+import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.Settings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -101,6 +104,8 @@ val chromaDiModule = module {
     single { FixtureRepository(get()) }
     single { NetworkStateRepository(get()) }
     single { PresetRepository(get()) }
+    single<ObservableSettings> { Settings() as ObservableSettings }
+    single { SettingsRepository(get()) }
 
     // --- Presets ---
     single { PresetLibrary(get(), get(), get()) }


### PR DESCRIPTION
This PR implements the `SettingsRepository` as part of the UX Rewrite plan. It uses the `multiplatform-settings` library to provide a reactive, cross-platform persistence layer for application preferences.

Key changes:
- Integrated `multiplatform-settings` (no-arg, coroutines, and test modules).
- Created `SettingsRepository` in `shared:core` with support for `masterDimmer`, `isSimulation`, `activePresetId`, `themePreference`, and `transportMode`.
- Added `SettingsRepositoryTest` in `shared:core:androidHostTest` verifying all get/set operations and Flow emissions.
- Wired the repository into the shared DI container (`ChromaDiModule`).

Verified with `./gradlew :shared:core:testAndroidHostTest`.

Fixes #84

---
*PR created automatically by Jules for task [5770346838796392865](https://jules.google.com/task/5770346838796392865) started by @srMarlins*