### PR TITLE
Add multiplatform-settings and turbine dependencies

### DIFF
--- a/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
@@ -60,6 +60,7 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                     commonTest.dependencies {
                         implementation(libs.findLibrary("kotlin-test").get())
                         implementation(libs.findLibrary("kotlinx-coroutines-test").get())
+                        implementation(libs.findLibrary("turbine").get())
                     }
 
                     androidMain.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,8 +36,12 @@ koog = "0.6.3"
 # SQLDelight
 sqldelight = "2.0.2"
 
+# Multiplatform Settings
+multiplatform-settings = "1.3.0"
+
 # Testing
 kotlin-test = "2.3.10"
+turbine = "1.2.0"
 
 [libraries]
 # Gradle Plugins (for build-logic convention plugins)
@@ -92,6 +96,14 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+
+# Multiplatform Settings
+multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
+multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
+multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatform-settings" }
+
+# Testing
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -40,5 +40,9 @@ kotlin {
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
         }
+
+        commonTest.dependencies {
+            implementation(libs.turbine)
+        }
     }
 }

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -15,6 +15,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.sqldelight.coroutines)
+            implementation(libs.multiplatform.settings)
+            implementation(libs.multiplatform.settings.coroutines)
         }
         androidMain.dependencies {
             implementation(libs.sqldelight.android.driver)


### PR DESCRIPTION
This change adds the `multiplatform-settings` and `Turbine` dependencies to the project as part of the UX Rewrite plan.

- `multiplatform-settings` (v1.3.0) and `multiplatform-settings-coroutines` are added to `shared:core` for persistent key-value storage.
- `turbine` (v1.2.0) is added to `commonTest` dependencies across all shared modules via the `KmpLibraryConventionPlugin` to facilitate testing of Kotlin Flows.
- Version catalog `gradle/libs.versions.toml` is updated with the new library definitions.

Fixes #81

---
*PR created automatically by Jules for task [6421890990920996483](https://jules.google.com/task/6421890990920996483) started by @srMarlins*