### PR TITLE
🎨 Palette: Add accessibility semantics to PixelSlider

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSlider.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSlider.kt
@@ -25,6 +25,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -101,6 +106,21 @@ fun PixelSlider(
                 .height(32.dp)
                 .fillMaxWidth()
                 .onSizeChanged { width = it.width }
+                .semantics(mergeDescendants = true) {
+                    if (!enabled) disabled()
+                    progressBarRangeInfo = ProgressBarRangeInfo(
+                        current = value,
+                        range = valueRange
+                    )
+                    setProgress { targetValue ->
+                        if (enabled && targetValue in valueRange) {
+                            onValueChange(targetValue)
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                }
                 .pointerInput(enabled) {
                     if (!enabled) return@pointerInput
                     detectTapGestures { offset ->

--- a/shared/src/commonTest/kotlin/com/chromadmx/ui/viewmodel/MascotViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/chromadmx/ui/viewmodel/MascotViewModelTest.kt
@@ -13,12 +13,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalNativeApi::class)
 class MascotViewModelTest {
 
     private fun stubBeatClock() = object : BeatClock {


### PR DESCRIPTION
This PR enhances the accessibility of the `PixelSlider` component by adding semantic information.
- Added `progressBarRangeInfo` to report the current value and range to screen readers.
- Implemented `setProgress` semantic action to allow programmatic adjustment of the slider value via accessibility services (e.g., TalkBack volume keys).
- Handles disabled state correctly in semantics.
- Fixed a build failure in `MascotViewModelTest.kt` related to `PlatformUdpTransport` usage in `commonTest` by adding the required `@OptIn(ExperimentalNativeApi::class)` annotation.

---
*PR created automatically by Jules for task [14649088571189067833](https://jules.google.com/task/14649088571189067833) started by @srMarlins*