### PR TITLE
Sentinel: Fix NodeDiscovery DoS vulnerability

### DIFF
--- a/shared/networking/src/commonTest/kotlin/com/chromadmx/networking/discovery/NodeDiscoverySecurityTest.kt
+++ b/shared/networking/src/commonTest/kotlin/com/chromadmx/networking/discovery/NodeDiscoverySecurityTest.kt
@@ -20,8 +20,10 @@ class NodeDiscoverySecurityTest {
     fun processReply_respectsMaxNodes() {
         val maxNodes = 10
         val discovery = NodeDiscovery(transport, maxNodes = maxNodes)
+        val startTime = 1000L
 
-        // Simulate receiving 100 unique nodes
+        // Simulate receiving 100 unique nodes, spread out over time
+        // We use increments of 10 seconds to ensure previous nodes become stale enough to be evicted
         for (i in 1..100) {
             val ip = byteArrayOf(10, 0, 0, i.toByte())
             val mac = byteArrayOf(0, 0, 0, 0, 0, i.toByte())
@@ -30,7 +32,9 @@ class NodeDiscoverySecurityTest {
                 macAddress = mac,
                 shortName = "Node-$i"
             )
-            discovery.processReply(reply, currentTimeMs = i.toLong())
+            // Increment time by 10s per node (well above the 5s degraded threshold)
+            val time = startTime + (i * 10_000L)
+            discovery.processReply(reply, currentTimeMs = time)
         }
 
         // Should be limited to maxNodes
@@ -42,8 +46,54 @@ class NodeDiscoverySecurityTest {
             assertTrue(discovery.nodes.value.containsKey(macStr), "Should contain node $i")
         }
 
-        // Node 1 should have been evicted
+        // Node 1 should have been evicted (it was seen very long ago)
         val mac1Str = "00:00:00:00:00:01"
         assertTrue(!discovery.nodes.value.containsKey(mac1Str), "Should NOT contain node 1")
+    }
+
+    @Test
+    fun processReply_protectsHealthyNodes_fromFlood() {
+        val maxNodes = 10
+        val discovery = NodeDiscovery(transport, maxNodes = maxNodes)
+        val startTime = 1000L
+
+        // 1. Fill the registry with 10 healthy nodes
+        for (i in 1..maxNodes) {
+            val ip = byteArrayOf(10, 0, 0, i.toByte())
+            val mac = byteArrayOf(0, 0, 0, 0, 0, i.toByte())
+            val reply = ArtNetCodec.encodeArtPollReply(
+                ipAddress = ip,
+                macAddress = mac,
+                shortName = "HealthyNode-$i"
+            )
+            // Seen at startTime
+            discovery.processReply(reply, currentTimeMs = startTime)
+        }
+
+        assertEquals(maxNodes, discovery.nodes.value.size)
+
+        // 2. Simulate an attack: A new node tries to join shortly after (1 second later)
+        // Since the existing nodes are fresh (latency < 5s), they should NOT be evicted.
+        val attackTime = startTime + 1000L
+        val attackIp = byteArrayOf(10, 0, 0, 99)
+        val attackMac = byteArrayOf(0, 0, 0, 0, 0, 99)
+        val attackReply = ArtNetCodec.encodeArtPollReply(
+            ipAddress = attackIp,
+            macAddress = attackMac,
+            shortName = "AttackerNode"
+        )
+        discovery.processReply(attackReply, currentTimeMs = attackTime)
+
+        // 3. Verify that the registry size is still maxNodes
+        assertEquals(maxNodes, discovery.nodes.value.size)
+
+        // 4. Verify that the attacker was REJECTED
+        // (It should not be in the map because no existing node was stale enough to evict)
+        val attackerKey = "00:00:00:00:00:63" // hex for 99
+        assertTrue(!discovery.nodes.value.containsKey(attackerKey), "Attacker node should have been rejected")
+
+        // 5. Verify that original nodes are still there
+        val node1Key = "00:00:00:00:00:01"
+        assertTrue(discovery.nodes.value.containsKey(node1Key), "Healthy node 1 should still be present")
     }
 }


### PR DESCRIPTION
This PR addresses a high-severity Denial of Service (DoS) vulnerability in the `NodeDiscovery` service.

Previously, the node discovery cache (limited to `maxNodes`, default 256) used a simple LRU-like eviction policy where the oldest node was removed to make room for any new node when the cache was full. This design was vulnerable to cache thrashing attacks, where a malicious actor could flood the network with fake ArtPollReply packets (sybils), forcing the eviction of legitimate, active DMX nodes.

The fix implements a "stale-only" eviction policy:
1. When the cache is full, we identify the oldest node.
2. We check if this node is "stale" (i.e., hasn't been seen for longer than `DmxNode.DEGRADED_TIMEOUT_MS` / 5000ms).
3. If it is stale, we evict it to make room for the new node (normal behavior for dynamic networks).
4. If it is **not** stale (i.e., it's a healthy, active node), we **reject the new node** instead.

This ensures that a flood of new packets cannot displace established, healthy nodes, effectively neutralizing the DoS attack while preserving the ability to discover new nodes when old ones drop offline.

Tests added:
- `NodeDiscoverySecurityTest`: Verifies that healthy nodes are protected from flood attacks.
- Updated `NodeDiscoveryTest`: Ensures standard eviction still functions correctly for stale nodes.

---
*PR created automatically by Jules for task [4702320414490887847](https://jules.google.com/task/4702320414490887847) started by @srMarlins*