### PR TITLE
feat(di): wire Koin DI with transport routers and V2 ViewModels (#99)

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
@@ -4,9 +4,11 @@ import com.chromadmx.core.db.ChromaDmxDatabase
 import com.chromadmx.core.db.DriverFactory
 import com.chromadmx.core.model.Fixture3D
 import com.chromadmx.core.persistence.FixtureRepository
+import com.chromadmx.core.persistence.FixtureStore
 import com.chromadmx.core.persistence.NetworkStateRepository
 import com.chromadmx.core.persistence.PresetRepository
 import com.chromadmx.core.persistence.SettingsRepository
+import com.chromadmx.core.persistence.SettingsStore
 import com.chromadmx.engine.bridge.DmxBridge
 import com.chromadmx.engine.bridge.DmxOutputBridge
 import com.chromadmx.engine.effect.EffectRegistry
@@ -19,25 +21,35 @@ import com.chromadmx.engine.effects.RainbowSweep3DEffect
 import com.chromadmx.engine.effects.SolidColorEffect
 import com.chromadmx.engine.effects.StrobeEffect
 import com.chromadmx.engine.effects.WaveEffect3DEffect
-import com.chromadmx.engine.effect.EffectStack
 import com.chromadmx.engine.pipeline.EffectEngine
 import com.chromadmx.engine.preset.PresetLibrary
+import com.chromadmx.networking.DmxTransport
+import com.chromadmx.networking.DmxTransportRouter
+import com.chromadmx.networking.FixtureDiscovery
+import com.chromadmx.networking.FixtureDiscoveryRouter
 import com.chromadmx.networking.discovery.NodeDiscovery
 import com.chromadmx.networking.output.DmxOutputService
 import com.chromadmx.networking.transport.PlatformUdpTransport
+import com.chromadmx.simulation.network.SimulatedDiscovery
+import com.chromadmx.simulation.network.SimulatedTransport
 import com.chromadmx.tempo.clock.BeatClock
 import com.chromadmx.tempo.tap.TapTempoClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 /**
  * Central DI module that wires all shared business logic:
- * tempo, networking, engine, and fixture provider.
+ * tempo, networking (real + simulated via routers), engine, and persistence.
  *
- * This lives in shared code (KMP-compatible). Platform-specific modules
- * (Android/iOS) only need to add platform transports if overriding defaults.
+ * The router pattern ([DmxTransportRouter], [FixtureDiscoveryRouter]) enables
+ * runtime switching between real hardware and simulation without restarting.
+ * Named qualifiers ("real" / "simulated") disambiguate the two implementations
+ * while the unqualified [DmxTransport] and [FixtureDiscovery] bindings resolve
+ * to the routers, giving consumers a single dependency.
  */
 val chromaDiModule = module {
 
@@ -45,17 +57,33 @@ val chromaDiModule = module {
     single { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
 
     // --- Tempo ---
-    // Currently using TapTempoClock directly. To enable Ableton Link with
-    // automatic fallback to tap-tempo, replace this binding with:
-    //   includes(com.chromadmx.tempo.di.tempoModule)
-    // and remove the single<BeatClock> line below.
-    // See: shared/tempo/src/commonMain/.../di/TempoModule.kt
     single<BeatClock> { TapTempoClock(scope = get()) }
 
-    // --- Networking ---
+    // --- Networking: Real ---
     single { PlatformUdpTransport() }
     single { NodeDiscovery(transport = get()) }
-    single { DmxOutputService(transport = get()) }
+    single(named("real")) { DmxOutputService(transport = get()) } bind DmxTransport::class
+
+    // --- Networking: Simulated ---
+    single(named("simulated")) { SimulatedTransport() } bind DmxTransport::class
+    single(named("simulated")) { SimulatedDiscovery() } bind FixtureDiscovery::class
+
+    // --- Networking: Routers ---
+    single {
+        DmxTransportRouter(
+            real = get(named("real")),
+            simulated = get(named("simulated")),
+            scope = get(),
+        )
+    } bind DmxTransport::class
+
+    single {
+        FixtureDiscoveryRouter(
+            real = get<NodeDiscovery>(),
+            simulated = get(named("simulated")),
+            scope = get(),
+        )
+    } bind FixtureDiscovery::class
 
     // --- Engine ---
     single {
@@ -79,7 +107,7 @@ val chromaDiModule = module {
     }
     single { get<EffectEngine>().effectStack }
 
-    // --- Engine -> DMX Bridge ---
+    // --- Engine -> DMX Bridge (routed through transport router) ---
     single {
         val engine = get<EffectEngine>()
         DmxBridge(engine.fixtures, emptyMap())
@@ -87,11 +115,11 @@ val chromaDiModule = module {
     single {
         val engine = get<EffectEngine>()
         val bridge = get<DmxBridge>()
-        val outputService = get<DmxOutputService>()
+        val router = get<DmxTransportRouter>()
         DmxOutputBridge(
             colorOutput = engine.colorOutput,
             dmxBridge = bridge,
-            onFrame = { frame -> outputService.updateFrame(frame) },
+            onFrame = { frame -> router.updateFrame(frame) },
             scope = get()
         ).apply { start() }
     }
@@ -99,14 +127,14 @@ val chromaDiModule = module {
     // --- Database ---
     single { get<DriverFactory>().createDriver() }
     single { ChromaDmxDatabase(get()) }
-    single { FixtureRepository(get()) }
+    single { FixtureRepository(get()) } bind FixtureStore::class
     single { NetworkStateRepository(get()) }
     single { PresetRepository(get()) }
-    single { SettingsRepository(get()) }
+    single { SettingsRepository(get()) } bind SettingsStore::class
 
     // --- Presets ---
     single { PresetLibrary(get(), get(), get()) }
 
-    // --- Fixture provider (empty default — StageViewModel manages fixtures) ---
+    // --- Fixture provider (empty default — StageViewModelV2 manages fixtures) ---
     single<() -> List<Fixture3D>> { { emptyList() } }
 }

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/ChromaDmxApp.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/ChromaDmxApp.kt
@@ -8,148 +8,101 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import com.chromadmx.simulation.fixtures.RigPreset
-import com.chromadmx.simulation.fixtures.SimulatedFixtureRig
 import com.chromadmx.ui.mascot.MascotOverlay
-import com.chromadmx.ui.util.presetDisplayName
-import com.chromadmx.ui.navigation.AppState
+import com.chromadmx.ui.navigation.AppScreen
 import com.chromadmx.ui.navigation.AppStateManager
 import com.chromadmx.ui.screen.chat.ChatPanel
-import com.chromadmx.ui.screen.onboarding.OnboardingFlow
 import com.chromadmx.ui.screen.settings.ProvisioningScreen
 import com.chromadmx.ui.screen.settings.SettingsScreen
-import com.chromadmx.ui.screen.simulation.RigPresetSelector
-import com.chromadmx.ui.screen.stage.StagePreviewScreen
+import com.chromadmx.ui.screen.setup.SetupScreen
+import com.chromadmx.ui.screen.stage.StageScreen
+import com.chromadmx.ui.state.MascotEvent
 import com.chromadmx.ui.theme.ChromaDmxTheme
-import com.chromadmx.ui.viewmodel.AgentViewModel
-import com.chromadmx.ui.viewmodel.MascotViewModel
 import com.chromadmx.ui.viewmodel.MascotViewModelV2
-import com.chromadmx.ui.viewmodel.OnboardingViewModel
 import com.chromadmx.ui.viewmodel.ProvisioningViewModel
-import com.chromadmx.ui.viewmodel.SettingsViewModel
 import com.chromadmx.ui.viewmodel.SettingsViewModelV2
-import com.chromadmx.ui.viewmodel.StageViewModel
+import com.chromadmx.ui.viewmodel.SetupViewModel
+import com.chromadmx.ui.viewmodel.StageViewModelV2
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.koin.compose.getKoin
 
 /**
  * Root composable for the ChromaDMX application.
  *
- * Uses [AppStateManager] for navigation: Onboarding -> StagePreview <-> Settings.
- * No tab bar. Single main screen with contextual overlays.
+ * Uses [AppStateManager] for 4-screen navigation:
+ * Setup -> Stage <-> Settings <-> Provisioning.
  *
- * On first launch the [OnboardingViewModel] drives a 6-step flow
- * (Splash -> NetworkDiscovery -> FixtureScan -> VibeCheck -> StagePreview -> Complete).
- * On repeat launches the app starts directly at StagePreview, performs a quick
- * network health check, and the mascot alerts if the network topology changed.
- *
- * Simulation mode is coordinated between [SettingsViewModel] (toggle/preset) and
- * [StageViewModel] (badge visibility, fixture count). The rig selector is accessible
- * from both the onboarding flow and the settings screen.
+ * All ViewModels follow UDF — single [state] flow, single [onEvent] entry.
+ * The mascot overlay and chat panel are global layers above all screens.
  */
 @Composable
 fun ChromaDmxApp() {
     ChromaDmxTheme {
-        val onboardingVm = resolveOrNull<OnboardingViewModel>()
-        val isFirstLaunch = remember { onboardingVm?.isFirstLaunch() ?: false }
-        val appStateManager = remember { AppStateManager(isFirstLaunch = isFirstLaunch) }
-        val currentState by appStateManager.currentState.collectAsState()
+        val appStateManager = resolveOrNull<AppStateManager>()
+        val currentScreen by appStateManager?.currentScreen?.collectAsState()
+            ?: remember { MutableStateFlow(AppScreen.Setup) }.collectAsState()
 
-        val settingsVm = resolveOrNull<SettingsViewModel>()
-        val settingsVmV2 = resolveOrNull<SettingsViewModelV2>()
-        val stageVm = resolveOrNull<StageViewModel>()
-        val mascotVm = resolveOrNull<MascotViewModel>()
-
-        // Repeat launch: quick network health check + mascot alert
-        if (!isFirstLaunch && onboardingVm != null) {
-            LaunchedEffect(Unit) {
-                onboardingVm.performRepeatLaunchCheck()
-            }
-
-            val networkChanged by onboardingVm.networkChanged.collectAsState()
-            val repeatCheckDone by onboardingVm.repeatLaunchComplete.collectAsState()
-
-            if (repeatCheckDone && networkChanged && mascotVm != null) {
-                LaunchedEffect(Unit) {
-                    mascotVm.triggerAlert("Network has changed since last session!")
-                }
-            }
-        }
-
-        // Read simulation state from SettingsViewModel
-        val simulationEnabled = settingsVm?.simulationEnabled?.collectAsState()?.value ?: false
-        val selectedRigPreset = settingsVm?.selectedRigPreset?.collectAsState()?.value ?: RigPreset.SMALL_DJ
+        val setupVm = resolveOrNull<SetupViewModel>()
+        val stageVm = resolveOrNull<StageViewModelV2>()
+        val settingsVm = resolveOrNull<SettingsViewModelV2>()
+        val mascotVm = resolveOrNull<MascotViewModelV2>()
 
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
-                when (val state = currentState) {
-                    is AppState.Onboarding -> {
-                        if (onboardingVm != null) {
-                            // Start the onboarding flow
-                            DisposableEffect(onboardingVm) {
-                                onboardingVm.start()
-                                onDispose { onboardingVm.onCleared() }
-                            }
-
-                            OnboardingFlow(
-                                viewModel = onboardingVm,
+                when (currentScreen) {
+                    AppScreen.Setup -> {
+                        if (setupVm != null) {
+                            SetupScreen(
+                                viewModel = setupVm,
                                 onComplete = {
-                                    // Sync simulation state from onboarding to settings/stage
-                                    val isSimMode = onboardingVm.isSimulationMode.value
-                                    if (isSimMode) {
-                                        val preset = onboardingVm.selectedRigPreset.value
-                                        settingsVm?.toggleSimulation(true)
-                                        settingsVm?.setRigPreset(preset)
-                                        val rig = SimulatedFixtureRig(preset)
-                                        stageVm?.enableSimulation(
-                                            presetName = preset.presetDisplayName(),
-                                            fixtureCount = rig.fixtureCount,
-                                        )
-                                    }
-                                    appStateManager.completeOnboarding()
+                                    appStateManager?.completeSetup()
                                 },
                             )
                         } else {
-                            // Fallback if OnboardingViewModel is not in DI
                             ScreenPlaceholder(
-                                "Onboarding",
-                                "OnboardingViewModel not registered in DI.",
+                                "Setup",
+                                "SetupViewModel not registered in DI.",
                             )
                         }
                     }
-                    is AppState.StagePreview -> {
+                    AppScreen.Stage -> {
                         if (stageVm != null) {
-                            StagePreviewScreen(
+                            StageScreen(
                                 viewModel = stageVm,
-                                onSettingsClick = { appStateManager.navigateTo(AppState.Settings) },
+                                onSettings = {
+                                    appStateManager?.navigateTo(AppScreen.Settings)
+                                },
                             )
                         } else {
-                            ScreenPlaceholder("Stage Preview", "Engine services not yet registered in DI.")
+                            ScreenPlaceholder(
+                                "Stage",
+                                "Engine services not registered in DI.",
+                            )
                         }
                     }
-                    is AppState.Settings -> {
-                        if (settingsVmV2 != null) {
+                    AppScreen.Settings -> {
+                        if (settingsVm != null) {
                             SettingsScreen(
-                                viewModel = settingsVmV2,
-                                onBack = { appStateManager.navigateBack() },
+                                viewModel = settingsVm,
+                                onBack = { appStateManager?.navigateBack() },
                                 onProvisioning = {
-                                    appStateManager.navigateTo(AppState.BleProvisioning)
+                                    appStateManager?.navigateTo(AppScreen.Provisioning)
                                 },
                             )
                         } else {
                             ScreenPlaceholder("Settings", "Services not registered.")
                         }
                     }
-                    is AppState.BleProvisioning -> {
+                    AppScreen.Provisioning -> {
                         val provisioningVm = resolveOrNull<ProvisioningViewModel>()
                         if (provisioningVm != null) {
                             DisposableEffect(provisioningVm) {
@@ -157,55 +110,28 @@ fun ChromaDmxApp() {
                             }
                             ProvisioningScreen(
                                 viewModel = provisioningVm,
-                                onClose = { appStateManager.navigateBack() },
+                                onClose = { appStateManager?.navigateBack() },
                             )
                         } else {
-                            ScreenPlaceholder("BLE Provisioning", "BLE services not registered.")
+                            ScreenPlaceholder(
+                                "BLE Provisioning",
+                                "BLE services not registered.",
+                            )
                         }
-                    }
-                    is AppState.RigSelection -> {
-                        RigPresetSelector(
-                            selectedPreset = selectedRigPreset,
-                            onSelectPreset = { preset ->
-                                settingsVm?.setRigPreset(preset)
-                            },
-                            onConfirm = {
-                                // Enable simulation with the selected preset
-                                settingsVm?.toggleSimulation(true)
-
-                                val rig = SimulatedFixtureRig(selectedRigPreset)
-                                stageVm?.enableSimulation(
-                                    presetName = selectedRigPreset.presetDisplayName(),
-                                    fixtureCount = rig.fixtureCount,
-                                )
-
-                                if (state.returnToOnboarding) {
-                                    appStateManager.navigateTo(
-                                        AppState.Onboarding
-                                    )
-                                } else {
-                                    appStateManager.navigateBack()
-                                }
-                            },
-                        )
                     }
                 }
 
-                // Pixel mascot overlay -- always visible on top of all screens
+                // Pixel mascot overlay — always visible on top of all screens
                 if (mascotVm != null) {
-                    DisposableEffect(mascotVm) {
-                        onDispose { mascotVm.onCleared() }
-                    }
                     MascotOverlay(
                         viewModel = mascotVm,
-                        onMascotTap = { mascotVm.toggleChat() },
+                        onMascotTap = { mascotVm.onEvent(MascotEvent.ToggleChat) },
                     )
                 }
 
-                // Chat panel overlay -- slides up when mascot is tapped
-                val mascotV2 = resolveOrNull<MascotViewModelV2>()
-                if (mascotV2 != null) {
-                    ChatPanel(viewModel = mascotV2)
+                // Chat panel overlay — slides up when mascot is tapped
+                if (mascotVm != null) {
+                    ChatPanel(viewModel = mascotVm)
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/mascot/MascotOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/mascot/MascotOverlay.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.chromadmx.ui.state.MascotEvent
 import com.chromadmx.ui.viewmodel.MascotViewModel
+import com.chromadmx.ui.viewmodel.MascotViewModelV2
 import kotlin.math.roundToInt
+import com.chromadmx.ui.state.SpeechBubble as StateSpeechBubble
 
 /**
  * Full-screen overlay that positions the mascot sprite and speech bubble.
@@ -82,3 +85,78 @@ fun MascotOverlay(
         }
     }
 }
+
+/**
+ * V2-compatible overlay that accepts [MascotViewModelV2] and adapts
+ * the UDF state to the sprite/bubble composables.
+ *
+ * Uses [AnimationController] from the ViewModel for frame-accurate
+ * sprite rendering and converts [StateSpeechBubble] to the mascot-layer
+ * [SpeechBubble] for [SpeechBubbleView].
+ */
+@Composable
+fun MascotOverlay(
+    viewModel: MascotViewModelV2,
+    onMascotTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val mascotState by viewModel.animationController.currentState.collectAsState()
+    val frameIndex by viewModel.animationController.currentFrameIndex.collectAsState()
+    val uiState by viewModel.state.collectAsState()
+
+    // Draggable offset (starts at bottom-right)
+    var offsetX by remember { mutableStateOf(0f) }
+    var offsetY by remember { mutableStateOf(0f) }
+
+    val animation = MascotSprites.animationFor(mascotState)
+    val frame = animation.frameAt(frameIndex)
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+                .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+                .clickable { onMascotTap() }
+                .pointerInput(Unit) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        offsetX += dragAmount.x
+                        offsetY += dragAmount.y
+                    }
+                },
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // Speech bubble (above mascot)
+            val bubble = uiState.currentBubble
+            if (bubble != null) {
+                SpeechBubbleView(
+                    bubble = bubble.toMascotBubble(),
+                    onDismiss = { viewModel.onEvent(MascotEvent.DismissBubble) },
+                    onAction = { actionId ->
+                        viewModel.onEvent(MascotEvent.OnBubbleAction(actionId))
+                    },
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
+            // Mascot sprite
+            SpriteRenderer(
+                frame = frame,
+                size = 64.dp,
+            )
+        }
+    }
+}
+
+/**
+ * Convert UDF [StateSpeechBubble] to mascot-layer [SpeechBubble].
+ * Both types share the same [BubbleType] enum so the conversion is 1:1.
+ */
+private fun StateSpeechBubble.toMascotBubble(): SpeechBubble = SpeechBubble(
+    text = text,
+    type = type,
+    actionLabel = actionLabel,
+    actionId = actionId,
+    autoDismissMs = autoDismissMs,
+)


### PR DESCRIPTION
## Summary
- Wire `DmxTransportRouter` and `FixtureDiscoveryRouter` with named qualifiers (real/simulated)
- Bind `FixtureRepository` as `FixtureStore` and `SettingsRepository` as `SettingsStore` for interface-based DI
- Route `DmxOutputBridge` through transport router instead of direct `DmxOutputService`
- Migrate `ChromaDmxApp.kt` to V2 ViewModels and `AppScreen` navigation
- Wire V2 ViewModels (`StageViewModelV2`, `SettingsViewModelV2`, `MascotViewModelV2`, `SetupViewModel`) in `UiModule`

Closes #99