### PR TITLE
fix: address PR #118 review — screen flow clarity, masked API key safety

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/ChromaDmxApp.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/ChromaDmxApp.kt
@@ -45,8 +45,9 @@ import org.koin.compose.getKoin
 fun ChromaDmxApp() {
     ChromaDmxTheme {
         val appStateManager = resolveOrNull<AppStateManager>()
-        val currentScreen by appStateManager?.currentScreen?.collectAsState()
-            ?: remember { MutableStateFlow(AppScreen.Setup) }.collectAsState()
+        val fallbackScreen = remember { MutableStateFlow(AppScreen.Setup) }
+        val currentScreenFlow = appStateManager?.currentScreen ?: fallbackScreen
+        val currentScreen by currentScreenFlow.collectAsState()
 
         val setupVm = resolveOrNull<SetupViewModel>()
         val stageVm = resolveOrNull<StageViewModelV2>()

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -299,23 +299,23 @@ private fun AgentSection(
         Column(
             verticalArrangement = Arrangement.spacedBy(PixelDesign.spacing.medium),
         ) {
-            // API Key (masked display)
-            val maskedKey = if (state.agentConfig.apiKey.isEmpty()) {
-                ""
+            // API Key (masked display — auto-unmask on edit)
+            var showKey by remember { mutableStateOf(false) }
+            val displayValue = if (showKey || state.agentConfig.apiKey.isEmpty()) {
+                state.agentConfig.apiKey
             } else {
                 "\u2022".repeat(state.agentConfig.apiKey.length.coerceAtMost(20))
             }
-            var showKey by remember { mutableStateOf(false) }
             PixelTextField(
-                value = if (showKey) state.agentConfig.apiKey else maskedKey,
+                value = displayValue,
                 onValueChange = { newValue ->
-                    // When masked, clear and start fresh; when visible, update normally
-                    val actualValue = if (!showKey && newValue.contains("\u2022")) {
-                        newValue.replace("\u2022", "")
+                    if (!showKey) {
+                        // First keystroke while masked: unmask and start fresh
+                        showKey = true
+                        onEvent(SettingsEvent.UpdateAgentConfig(state.agentConfig.copy(apiKey = newValue.filter { it != '\u2022' })))
                     } else {
-                        newValue
+                        onEvent(SettingsEvent.UpdateAgentConfig(state.agentConfig.copy(apiKey = newValue)))
                     }
-                    onEvent(SettingsEvent.UpdateAgentConfig(state.agentConfig.copy(apiKey = actualValue)))
                 },
                 label = "API Key",
                 placeholder = "Enter API key...",


### PR DESCRIPTION
## Summary
Addresses Gemini code review findings from PR #118:

- **GlobalScope (HIGH)**: Already fixed in PR #111 — legacy constructor uses `CoroutineScope(SupervisorJob())`, not `GlobalScope`. No change needed.
- **currentScreen flow (MEDIUM)**: Split chained `?.collectAsState() ?: remember { ... }.collectAsState()` into separate vals for readability
- **Masked API key (MEDIUM)**: Replace fragile `replace("\u2022", "")` with auto-unmask on first keystroke — avoids incorrect behavior if API key contains bullet character