### PR TITLE
fix(di): register BLE and DmxOutputService bindings

### DIFF
--- a/android/app/src/main/kotlin/com/chromadmx/android/ChromaDMXApp.kt
+++ b/android/app/src/main/kotlin/com/chromadmx/android/ChromaDMXApp.kt
@@ -7,6 +7,8 @@ import com.chromadmx.core.db.DriverFactory
 import com.chromadmx.core.persistence.AndroidFileStorage
 import com.chromadmx.core.persistence.FileStorage
 import com.chromadmx.di.chromaDiModule
+import com.chromadmx.networking.ble.BleProvisioner
+import com.chromadmx.networking.ble.BleScanner
 import com.chromadmx.ui.di.uiModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -26,6 +28,8 @@ class ChromaDMXApp : Application() {
         val androidPlatformModule = module {
             single<FileStorage> { AndroidFileStorage(get()) }
             single { DriverFactory(get()) }
+            single { BleScanner() }
+            single { BleProvisioner() }
             single {
                 val googleKey = BuildConfig.GOOGLE_API_KEY
                 val anthropicKey = BuildConfig.ANTHROPIC_API_KEY

--- a/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/di/ChromaDiModule.kt
@@ -62,7 +62,8 @@ val chromaDiModule = module {
     // --- Networking: Real ---
     single { PlatformUdpTransport() }
     single { NodeDiscovery(transport = get()) }
-    single(named("real")) { DmxOutputService(transport = get()) } bind DmxTransport::class
+    single { DmxOutputService(transport = get()) }
+    single(named("real")) { get<DmxOutputService>() } bind DmxTransport::class
 
     // --- Networking: Simulated ---
     single(named("simulated")) { SimulatedTransport() } bind DmxTransport::class


### PR DESCRIPTION
## Summary
- Register `BleScanner` and `BleProvisioner` in the Android platform module so `BleProvisioningService` can resolve its dependencies — without this, the BLE provisioning screen silently fails (service is null)
- Split `DmxOutputService` into an unqualified `single` + `named("real")` alias so `get<DmxOutputService>()` in the agent module resolves correctly

## Test plan
- [x] `compileCommonMainKotlinMetadata` passes
- [x] `compileDebugKotlin` passes
- [ ] Verify BLE provisioning screen loads without "BLE services not registered" placeholder
- [ ] Verify agent features resolve DmxOutputService at runtime