### PR TITLE
fix(db): add SQLDelight schema migration v1→v2

### DIFF
--- a/shared/core/src/commonMain/sqldelight/migrations/1.sqm
+++ b/shared/core/src/commonMain/sqldelight/migrations/1.sqm
@@ -1,0 +1,20 @@
+-- Migration from schema version 1 to 2.
+-- Adds tables introduced after the initial schema: known_node and app_settings.
+
+CREATE TABLE IF NOT EXISTS known_node (
+    node_key TEXT NOT NULL PRIMARY KEY,
+    ip_address TEXT NOT NULL,
+    short_name TEXT NOT NULL,
+    long_name TEXT NOT NULL,
+    last_seen_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS app_settings (
+    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+    master_dimmer REAL NOT NULL DEFAULT 1.0,
+    is_simulation INTEGER NOT NULL DEFAULT 0,
+    active_preset_id TEXT,
+    theme_preference TEXT NOT NULL DEFAULT 'MatchaDark',
+    transport_mode TEXT NOT NULL DEFAULT 'Real',
+    setup_completed INTEGER NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- Adds `1.sqm` migration file that creates `app_settings` and `known_node` tables with `IF NOT EXISTS`
- Bumps schema version from 1 to 2 (automatic via SQLDelight migration detection)
- Fixes crash: `no such table: app_settings` on existing installs where the database was created before Settings.sq was added

## Root cause
Tables were added to the .sq schema across multiple PRs but the schema version stayed at 1 with no migrations. Existing databases already had version 1 so SQLDelight skipped `create()`, leaving the new tables missing.

## Test plan
- [x] `generateCommonMainChromaDmxDatabaseInterface` — schema version now 2
- [x] Generated `migrateInternal` creates both tables when upgrading 1→2
- [x] `compileDebugKotlin` passes
- [ ] Verify app launches on device with existing database without crash