### PR TITLE
🎨 Palette: Add explicit Button role to interactive components

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
@@ -84,7 +84,8 @@ fun PixelButton(
                 interactionSource = interactionSource,
                 indication = null,
                 enabled = enabled,
-                onClick = onClick
+                onClick = onClick,
+                role = androidx.compose.ui.semantics.Role.Button
             )
             .padding(top = pressDepth) // Reserve space for the "up" state
     ) {

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelCard.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelCard.kt
@@ -67,6 +67,7 @@ fun PixelCard(
                             interactionSource = interactionSource,
                             indication = null,
                             onClick = onClick,
+                            role = androidx.compose.ui.semantics.Role.Button,
                         )
                     } else {
                         mod

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -124,6 +124,7 @@ fun PixelIconButton(
                 indication = null,
                 enabled = enabled,
                 onClick = onClick,
+                role = androidx.compose.ui.semantics.Role.Button,
             ),
         contentAlignment = Alignment.Center,
     ) {

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelDataDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelDataDisplay.kt
@@ -90,6 +90,7 @@ fun PixelListItem(
                             interactionSource = interactionSource,
                             indication = null,
                             onClick = onClick,
+                            role = androidx.compose.ui.semantics.Role.Button,
                         )
                     } else {
                         mod
@@ -190,6 +191,7 @@ fun PixelChip(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClick,
+                role = androidx.compose.ui.semantics.Role.Button,
             )
             .let { mod ->
                 if (selected) {
@@ -383,10 +385,13 @@ fun PixelToast(
                             fontFamily = PixelFontFamily,
                         ),
                         modifier = Modifier
-                            .clickable(onClick = {
-                                onAction()
-                                onDismiss()
-                            }),
+                            .clickable(
+                                onClick = {
+                                    onAction()
+                                    onDismiss()
+                                },
+                                role = androidx.compose.ui.semantics.Role.Button,
+                            ),
                     )
                 }
             }


### PR DESCRIPTION
💡 What: Added `role = Role.Button` to the `clickable` modifiers of `PixelButton`, `PixelCard`, `PixelIconButton`, `PixelListItem`, `PixelChip`, and action buttons in `PixelToast`.
🎯 Why: Without explicit semantics, Compose does not natively communicate to screen readers that these custom clickable layouts function as buttons. This ensures correct announcements via TalkBack and VoiceOver.
♿ Accessibility: Ensures custom UI components are identified accurately as `Button` interactions rather than generic clickable areas.

---
*PR created automatically by Jules for task [2578596987354431694](https://jules.google.com/task/2578596987354431694) started by @srMarlins*