### PR TITLE
⚡ Bolt: Eliminate intermediate allocations in DMX engine hot path

### DIFF
--- a/shared/core/src/commonMain/kotlin/com/chromadmx/core/model/FixtureOutput.kt
+++ b/shared/core/src/commonMain/kotlin/com/chromadmx/core/model/FixtureOutput.kt
@@ -90,7 +90,7 @@ data class FixtureOutput(
          * For ADDITIVE mode, the overlay is added as an offset.
          * For other modes, the overlay replaces the base, lerped by opacity.
          */
-        internal fun blendFloat(
+        fun blendFloat(
             base: Float?,
             overlay: Float?,
             mode: BlendMode,

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
@@ -88,9 +88,13 @@ class DmxBridge(
         profile: FixtureProfile,
         color: Color
     ) {
-        val clamped = color.clamped()
+        // Optimization: bypass clamped() to prevent allocating a Color object per fixture per frame
+        val cr = color.r.coerceIn(0f, 1f)
+        val cg = color.g.coerceIn(0f, 1f)
+        val cb = color.b.coerceIn(0f, 1f)
+
         val hasDimmer = profile.channelByType(ChannelType.DIMMER) != null
-        val brightness = maxOf(clamped.r, clamped.g, clamped.b)
+        val brightness = maxOf(cr, cg, cb)
 
         for (channel in profile.channels) {
             val addr = channelStart + channel.offset
@@ -98,15 +102,15 @@ class DmxBridge(
 
             data[addr] = when (channel.type) {
                 ChannelType.RED -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.r / brightness else clamped.r
+                    val value = if (hasDimmer && brightness > 0f) cr / brightness else cr
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.GREEN -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.g / brightness else clamped.g
+                    val value = if (hasDimmer && brightness > 0f) cg / brightness else cg
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.BLUE -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.b / brightness else clamped.b
+                    val value = if (hasDimmer && brightness > 0f) cb / brightness else cb
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.DIMMER -> {
@@ -114,7 +118,7 @@ class DmxBridge(
                 }
                 ChannelType.WHITE -> {
                     // White = minimum of RGB (conservative approach)
-                    val white = minOf(clamped.r, clamped.g, clamped.b)
+                    val white = minOf(cr, cg, cb)
                     (white * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.STROBE -> channel.defaultValue.toByte()
@@ -129,9 +133,13 @@ class DmxBridge(
         profile: FixtureProfile,
         output: FixtureOutput
     ) {
-        val clamped = output.color.clamped()
+        // Optimization: bypass clamped() to prevent allocating a Color object per fixture per frame
+        val cr = output.color.r.coerceIn(0f, 1f)
+        val cg = output.color.g.coerceIn(0f, 1f)
+        val cb = output.color.b.coerceIn(0f, 1f)
+
         val hasDimmer = profile.channelByType(ChannelType.DIMMER) != null
-        val brightness = maxOf(clamped.r, clamped.g, clamped.b)
+        val brightness = maxOf(cr, cg, cb)
 
         for (channel in profile.channels) {
             val addr = channelStart + channel.offset
@@ -139,22 +147,22 @@ class DmxBridge(
 
             data[addr] = when (channel.type) {
                 ChannelType.RED -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.r / brightness else clamped.r
+                    val value = if (hasDimmer && brightness > 0f) cr / brightness else cr
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.GREEN -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.g / brightness else clamped.g
+                    val value = if (hasDimmer && brightness > 0f) cg / brightness else cg
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.BLUE -> {
-                    val value = if (hasDimmer && brightness > 0f) clamped.b / brightness else clamped.b
+                    val value = if (hasDimmer && brightness > 0f) cb / brightness else cb
                     (value * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.DIMMER -> {
                     (brightness * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.WHITE -> {
-                    val white = minOf(clamped.r, clamped.g, clamped.b)
+                    val white = minOf(cr, cg, cb)
                     (white * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
                 }
                 ChannelType.PAN -> {
@@ -206,12 +214,19 @@ class DmxBridge(
     }
 
     private fun writeSimpleRgb(data: ByteArray, channelStart: Int, color: Color) {
-        val bytes = color.toDmxBytes()
-        for (i in bytes.indices) {
-            val addr = channelStart + i
-            if (addr in 0 until 512) {
-                data[addr] = bytes[i]
-            }
+        // Optimization: prevent allocating a ByteArray and Color per fixture per frame by manually coercing
+        val cr = color.r.coerceIn(0f, 1f)
+        val cg = color.g.coerceIn(0f, 1f)
+        val cb = color.b.coerceIn(0f, 1f)
+
+        if (channelStart in 0 until 512) {
+            data[channelStart] = (cr * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+        }
+        if (channelStart + 1 in 0 until 512) {
+            data[channelStart + 1] = (cg * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+        }
+        if (channelStart + 2 in 0 until 512) {
+            data[channelStart + 2] = (cb * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
         }
     }
 }

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/effect/EffectStack.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/effect/EffectStack.kt
@@ -213,8 +213,14 @@ class EffectStack(
             // First evaluate color stack
             val color = evaluate(pos)
 
-            // Start with the color result
-            var result = FixtureOutput(color = color)
+            // Optimization: Avoid allocating intermediate FixtureOutput instances per movement layer
+            // by accumulating properties individually and constructing the final object once.
+            var pan: Float? = null
+            var tilt: Float? = null
+            var gobo: Int? = null
+            var focus: Float? = null
+            var zoom: Float? = null
+            var strobeRate: Float? = null
 
             // Composite movement layers
             for (i in movementLayers.indices) {
@@ -222,14 +228,26 @@ class EffectStack(
                 if (!layer.enabled) continue
 
                 val layerOutput = layer.effect.computeMovement(pos, movementContexts[i])
-                result = result.blendMovementOnly(
-                    other = layerOutput,
-                    mode = layer.blendMode,
-                    opacity = layer.opacity
-                )
+                val mode = layer.blendMode
+                val op = layer.opacity.coerceIn(0f, 1f)
+
+                pan = FixtureOutput.blendFloat(pan, layerOutput.pan, mode, op)
+                tilt = FixtureOutput.blendFloat(tilt, layerOutput.tilt, mode, op)
+                gobo = if (layerOutput.gobo != null && op > 0f) layerOutput.gobo else gobo
+                focus = FixtureOutput.blendFloat(focus, layerOutput.focus, mode, op)
+                zoom = FixtureOutput.blendFloat(zoom, layerOutput.zoom, mode, op)
+                strobeRate = FixtureOutput.blendFloat(strobeRate, layerOutput.strobeRate, mode, op)
             }
 
-            return result
+            return FixtureOutput(
+                color = color,
+                pan = pan,
+                tilt = tilt,
+                gobo = gobo,
+                focus = focus,
+                zoom = zoom,
+                strobeRate = strobeRate
+            )
         }
 
         /** Whether this frame has any movement layers. */


### PR DESCRIPTION
⚡ Bolt: Eliminate intermediate allocations in DMX engine hot path

💡 What:
1. In `EffectStack.kt`, inlined the property accumulation during movement layer evaluation to construct `FixtureOutput` exactly once per fixture.
2. In `DmxBridge.kt`, bypassed `.clamped()` and `.toDmxBytes()` by explicitly coercing and evaluating `Color` components (`r`, `g`, `b`) directly.

🎯 Why:
The DMX rendering loop runs at 60 fps for every fixture. Previously, operations like `.blendMovementOnly()` created intermediate `FixtureOutput` objects for every movement layer per fixture. Similarly, `.clamped()` and `.toDmxBytes()` allocated new `Color` and `ByteArray` objects per fixture per frame. This caused aggressive garbage collection (GC) pressure, leading to frame drops.

📊 Impact:
- Prevents generating ~15,000+ objects per second for an average rig (e.g. 50 fixtures, 3 layers @ 60fps).
- Significant reduction in GC pauses and memory churn, yielding a smoother and more stable framerate.

🔬 Measurement:
Profile memory allocation rate under normal rendering. Notice a severe drop in the allocation of `Color`, `FixtureOutput`, and `ByteArray` instances during evaluation compared to before the patch.

---
*PR created automatically by Jules for task [5951058426100394410](https://jules.google.com/task/5951058426100394410) started by @srMarlins*