### PR TITLE
🎨 Palette: Add Semantic Role to PixelDropdown

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -167,7 +167,10 @@ fun PixelDropdown(
                 .pixelBorder(chamfer = 6.dp)
                 .clip(PixelShape.Small)
                 .background(PixelDesign.colors.surface, PixelShape.Small)
-                .clickable { expanded = true }
+                .clickable(
+                    role = androidx.compose.ui.semantics.Role.DropdownList,
+                    onClick = { expanded = true }
+                )
                 .padding(horizontal = 12.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
🎨 Palette: Add Semantic Role to PixelDropdown

- **What:** Added `role = Role.DropdownList` to the `PixelDropdown` trigger component in `PixelContainers.kt`.
- **Why:** This improves screen reader support, correctly informing users that this element expands a dropdown list rather than acting as a generic button.
- **Accessibility:** Direct improvement to component semantics for assistive technologies.

---
*PR created automatically by Jules for task [3791249987166575336](https://jules.google.com/task/3791249987166575336) started by @srMarlins*