### PR TITLE
⚡ Bolt: Avoid intermediate allocations in DMX packColor and setColor

### DIFF
--- a/shared/core/src/commonMain/kotlin/com/chromadmx/core/model/DMXUniverse.kt
+++ b/shared/core/src/commonMain/kotlin/com/chromadmx/core/model/DMXUniverse.kt
@@ -42,8 +42,10 @@ data class DMXUniverse(
         require(startChannel in 0..(DMX_CHANNEL_COUNT - 3)) {
             "Cannot write 3-byte color at channel $startChannel"
         }
-        val bytes = color.toDmxBytes()
-        bytes.copyInto(channels, startChannel)
+        // Optimization: avoid allocating an intermediate ByteArray and Color object per call
+        channels[startChannel] = (color.r.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+        channels[startChannel + 1] = (color.g.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+        channels[startChannel + 2] = (color.b.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
     }
 
     /** Read an RGB [Color] from [startChannel] (3 consecutive channels). */

--- a/shared/core/src/commonMain/kotlin/com/chromadmx/core/util/DmxExtensions.kt
+++ b/shared/core/src/commonMain/kotlin/com/chromadmx/core/util/DmxExtensions.kt
@@ -15,8 +15,10 @@ fun ByteArray.packColor(color: Color, offset: Int) {
     require(offset >= 0 && offset + 3 <= size) {
         "Cannot pack 3-byte color at offset $offset in array of size $size"
     }
-    val bytes = color.toDmxBytes()
-    bytes.copyInto(this, offset)
+    // Optimization: avoid allocating an intermediate ByteArray and Color object per call
+    this[offset] = (color.r.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+    this[offset + 1] = (color.g.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
+    this[offset + 2] = (color.b.coerceIn(0f, 1f) * 255f + 0.5f).toInt().coerceIn(0, 255).toByte()
 }
 
 /**


### PR DESCRIPTION
💡 What: Rewrote `ByteArray.packColor` and `DMXUniverse.setColor` to perform conversion math inline instead of calling `color.toDmxBytes()`.
🎯 Why: `color.toDmxBytes()` allocates a new `Color` (via `clamped()`) and a new `ByteArray` on every call. In a DMX engine hot loop, this creates thousands of short-lived objects per frame, leading to GC pressure and dropped frames.
📊 Impact: Eliminates 2 intermediate object allocations per pixel/fixture write per frame.
🔬 Measurement: Run unit tests using `./gradlew :shared:core:testAndroidHostTest` and `./gradlew :shared:engine:testAndroidHostTest`. Check profiler to see reduced `ByteArray` and `Color` memory allocations.

---
*PR created automatically by Jules for task [12802008421607165038](https://jules.google.com/task/12802008421607165038) started by @srMarlins*