### PR TITLE
🎨 Palette: Improve screen reader support for PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Use toggleable instead of clickable(role = Role.Switch) for switches
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` on switch components (like `PixelSwitch`) does not correctly announce their on/off state to screen readers.
+**Action:** Use `Modifier.toggleable` instead, which natively handles state announcements for switches, checkboxes, etc.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
**💡 What:** Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(...)` in the `PixelSwitch` component.

**🎯 Why:** In Compose Multiplatform, applying a `Switch` role to a standard clickable modifier does not guarantee proper state announcement by screen readers (like TalkBack). The natively supported way to handle this is using `Modifier.toggleable`, which natively communicates the state changes and semantics to accessibility services.

**♿ Accessibility:** This change ensures users relying on screen readers hear "On" or "Off" when navigating to or interacting with `PixelSwitch` components throughout the app.

Included an entry in `.jules/palette.md` to persist this learning.

---
*PR created automatically by Jules for task [4325628743748448690](https://jules.google.com/task/4325628743748448690) started by @srMarlins*