### PR TITLE
🎨 Palette: Use toggleable for PixelSwitch accessibility

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,12 +54,13 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
+            role = Role.Switch,
+            onValueChange = { onCheckedChange?.invoke(it) }
         )
         .let { mod ->
             if (checked && enabled) {


### PR DESCRIPTION
This PR improves accessibility for the `PixelSwitch` component.

💡 **What**: Changed the accessibility configuration of `PixelSwitch` from `Modifier.clickable(role = Role.Switch)` to `Modifier.toggleable(role = Role.Switch, value = checked, ...)`.

🎯 **Why**: Using `clickable` for switches causes screen readers to misinterpret the state of the component (e.g. failing to properly announce whether it is currently checked/unchecked). The `toggleable` modifier is the correct accessibility semantic in Compose for components with a boolean state like switches or checkboxes. This makes `PixelSwitch` fully accessible to visually impaired users relying on tools like TalkBack or VoiceOver.

♿ **Accessibility**: Replaced an unsemantic click handler with Compose's `toggleable` foundation interface, accurately announcing "on/off" states to screen readers.

---
*PR created automatically by Jules for task [5765821144097177879](https://jules.google.com/task/5765821144097177879) started by @srMarlins*