### PR TITLE
⚡ Bolt: Optimize ColorUtils.hsvToRgb by eliminating Triple allocations

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,18 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: Avoid intermediate Triple allocations in the render hot path
+        // which can cause GC pressure when evaluated thousands of times per frame.
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the `Triple` allocations inside the `when` expression of `ColorUtils.hsvToRgb` with primitive local variable assignments (`r1`, `g1`, `b1`).

🎯 **Why:** In the 60fps render loop, `hsvToRgb` is frequently called by effects like `RainbowSweep3DEffect`. Instantiating `Triple` objects continuously in this hot path generated significant unnecessary garbage collection (GC) pressure, which could lead to GC pauses and dropped frames.

📊 **Impact:** This optimization entirely eliminates object allocation per `hsvToRgb` call, reducing GC overhead and providing a smoother experience in the rendering engine.

🔬 **Measurement:** Verify with `./gradlew :shared:engine:testAndroidHostTest` to ensure that logic correctness is maintained without regression.

---
*PR created automatically by Jules for task [1648619986918239714](https://jules.google.com/task/1648619986918239714) started by @srMarlins*