### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential masking and auto-complete in Settings & Provisioning

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrect = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -728,21 +728,19 @@ private fun AgentSection(
         Column(
             verticalArrangement = Arrangement.spacedBy(PixelDesign.spacing.medium),
         ) {
-            // API Key (masked display — auto-unmask on edit)
-            var showKey by remember { mutableStateOf(false) }
+            // API Key (masked display — never auto-unmask to prevent shoulder surfing)
             PixelTextField(
                 value = state.agentConfig.apiKey,
                 onValueChange = { newValue ->
-                    if (!showKey) showKey = true
                     onEvent(SettingsEvent.UpdateAgentConfig(state.agentConfig.copy(apiKey = newValue)))
                 },
                 label = "API Key",
                 placeholder = "Enter API key...",
-                visualTransformation = if (showKey || state.agentConfig.apiKey.isEmpty()) {
-                    androidx.compose.ui.text.input.VisualTransformation.None
-                } else {
-                    androidx.compose.ui.text.input.PasswordVisualTransformation()
-                },
+                visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrect = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix credential masking and auto-complete in Settings & Provisioning

🚨 **Severity:** HIGH
💡 **Vulnerability:** The API key field in `SettingsScreen` previously unmasked the secret completely when editing began (`showKey` logic), allowing shoulder surfing. Furthermore, both the API key and the Wi-Fi password (`ProvisioningScreen`) allowed dictionary learning and autocomplete by the OS keyboard.
🎯 **Impact:** Allowed credential leakage via autocomplete caching or shoulder-surfing.
🔧 **Fix:** Removed the unmask-on-edit logic so the API Key always remains masked with `PasswordVisualTransformation()`. Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false)` to both fields.
✅ **Verification:** Verified compilation and tests pass. Looked at UI diffs to ensure the visual components and their states properly implement `KeyboardOptions` and permanent `VisualTransformation`.

---
*PR created automatically by Jules for task [17914041761152845083](https://jules.google.com/task/17914041761152845083) started by @srMarlins*