### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - PixelSwitch Accessibility Update
+**Learning:** Raw `Modifier.clickable(role = Role.Switch)` with boolean state doesn't fully expose the toggle semantics (like current state being checked vs unchecked) properly to screen readers for switch-like components.
+**Action:** Use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)` for custom switch components (like `PixelSwitch`) so that TalkBack correctly announces "On" or "Off" states to screen readers.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +54,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let {
+            if (onCheckedChange != null) {
+                it.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                it
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
Changed `PixelSwitch` to use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)` to improve accessibility. Also added a journal entry in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7029487791199627747](https://jules.google.com/task/7029487791199627747) started by @srMarlins*