### PR TITLE
🛡️ Sentinel: [HIGH] Prevent OS dictionary caching of secrets

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Sensitive inputs like API keys and Wi-Fi passwords were using `PasswordVisualTransformation()` to mask characters visually, but did not use the corresponding `KeyboardType.Password` option. This allows the OS keyboard to learn, cache, and attempt to auto-correct the sensitive values, potentially leaking secrets into the user's personal dictionary.
🎯 **Impact:** Exposes sensitive API keys and Wi-Fi passwords through OS keyboard predictions and caching.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the `PixelTextField` (for API keys) in `SettingsScreen.kt` and `OutlinedTextField` (for Wi-Fi passwords) in `ProvisioningScreen.kt`.
✅ **Verification:** Verified that tests pass via Gradle. Ensure your device keyboard no longer attempts to cache or autocorrect inputs in these fields.

---
*PR created automatically by Jules for task [3598779843238369789](https://jules.google.com/task/3598779843238369789) started by @srMarlins*