### PR TITLE
⚡ Bolt: Optimize hsvToRgb allocations

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,19 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: Prevent intermediate object allocations (e.g., Triple) in the rendering hot path.
+        // Using local primitive variables avoids boxing overhead and reduces GC pressure.
+        var r1 = 0f
+        var g1 = 0f
+        var b1 = 0f
+
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the `Triple` allocations with local mutable primitive variables (`r1`, `g1`, `b1`) in `ColorUtils.hsvToRgb`.
🎯 **Why:** To prevent intermediate object allocations and the hidden boxing overhead of primitive `Float` values into `java.lang.Float` in the DMX rendering engine's hot path. This optimization reduces GC pressure and helps prevent framerate drops.
📊 **Impact:** Reduces heap allocations by 4 objects per color conversion, drastically decreasing GC pauses.
🔬 **Measurement:** Verify by running the tests (`./gradlew :shared:engine:testAndroidHostTest`). You can observe the absence of intermediate object allocations via memory profiling during heavy DMX rendering.

---
*PR created automatically by Jules for task [14627848418789078780](https://jules.google.com/task/14627848418789078780) started by @srMarlins*