### PR TITLE
🎨 Palette: Add explicit accessibility roles to interactive custom components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Role in Custom Pixel Components
+**Learning:** Missing `role = Role.Button` on custom `Modifier.clickable` components prevents screen readers (like TalkBack) from correctly announcing them as interactive elements, leading to poor accessibility for visually impaired users.
+**Action:** Always explicitly set `role = Role.Button` (or other appropriate roles like `Role.DropdownList` or `Role.Switch`) on `Modifier.clickable` blocks when building custom interactive pixel-styled components.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chromadmx.core.model.DmxNode
 import com.chromadmx.ui.screen.network.HealthLevel
@@ -46,7 +47,10 @@ fun NodeHealthCompact(
 
     Row(
         modifier = modifier
-            .clickable { onClick() }
+            .clickable(
+                onClick = onClick,
+                role = Role.Button,
+            )
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.NeonMagenta
@@ -54,7 +55,10 @@ fun SimulationBadge(
     Box(
         modifier = modifier
             .alpha(alpha)
-            .clickable(onClick = onTap)
+            .clickable(
+                onClick = onTap,
+                role = Role.Button,
+            )
             .pixelBorder(color = NeonMagenta.copy(alpha = 0.6f), pixelSize = pixelSize)
             .background(NeonMagenta.copy(alpha = 0.25f))
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.chromadmx.ui.theme.PixelDesign
@@ -76,6 +77,7 @@ fun BpmDisplay(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onTap,
+                role = Role.Button,
             )
             .padding(horizontal = 4.dp, vertical = 4.dp),
         contentAlignment = Alignment.Center,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.PixelDesign
 import com.chromadmx.ui.theme.PixelFontFamily
@@ -48,7 +49,10 @@ fun NodeHealthBar(
 
     Row(
         modifier = modifier
-            .clickable(onClick = onExpand)
+            .clickable(
+                onClick = onExpand,
+                role = Role.Button,
+            )
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
💡 What: Added explicit `role = Role.Button` semantics to custom pixel-art interactive components (BpmDisplay, NodeHealthBar, NodeHealthCompact, and SimulationBadge). Also added a critical UX journal entry to `.jules/palette.md` to establish this pattern for the project.
🎯 Why: Without explicit roles on `Modifier.clickable`, custom Compose Multiplatform interactive elements are not announced properly by screen readers like TalkBack or VoiceOver, severely degrading the accessibility of the application.
♿ Accessibility: Ensures that visually impaired users know these elements are interactive and tappable.

---
*PR created automatically by Jules for task [10645594725885891314](https://jules.google.com/task/10645594725885891314) started by @srMarlins*