### PR TITLE
⚡ Bolt: [performance improvement] Avoid intermediate object allocations in ColorUtils.hsvToRgb

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2024-05-20 - [Avoid Intermediate Object Allocations in Render Loop]
+**Learning:** Returning intermediate objects like `Triple` in frequently called math functions (like `ColorUtils.hsvToRgb`) forces garbage collection in the 60fps render path, causing frame drops and GC pauses.
+**Action:** Use local primitive variables and early assignments to avoid allocating temporary wrapper objects like `Triple` during hot-path calculations.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,19 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: avoid allocating Triple objects in this frequently-called
+        // render path function by assigning to local primitive variables directly
+        val r1: Float
+        val g1: Float
+        val b1: Float
+
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 What: Replaced `Triple` allocations in `ColorUtils.hsvToRgb` with direct assignments to local primitive float variables. Added a journal entry to `.jules/bolt.md`.
🎯 Why: `hsvToRgb` is frequently called in the 60fps render engine path. Allocating an intermediate wrapper object like `Triple` inside the mathematical core creates thousands of unnecessary allocations per frame, leading to GC pauses and dropped frames.
📊 Impact: Reduces memory allocation and garbage collection pressure in the rendering engine's hot path by completely avoiding the instantiation of wrapper objects during HSV calculations.
🔬 Measurement: Verify by running tests via `./gradlew :shared:engine:testAndroidHostTest` and by profiling the application memory in the Android Studio Profiler; the total number of allocations for `kotlin.Pair` or `kotlin.Triple` during normal rendering will be observably lower.

---
*PR created automatically by Jules for task [7210652420445752453](https://jules.google.com/task/7210652420445752453) started by @srMarlins*