### PR TITLE
⚡ Bolt: Remove intermediate Triple allocations in hsvToRgb

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,17 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 What: Replaced the `Triple` object allocations within the `when` expression of the `hsvToRgb` color conversion function with local `Float` variable assignments (`r1`, `g1`, `b1`).

🎯 Why: The `Triple` instantiation and destructuring created temporary objects on the heap every time `hsvToRgb` was called. In the DMX rendering hot path, this function is called repeatedly for every pixel/fixture per frame (60fps), generating significant garbage and leading to potential GC pauses and dropped frames.

📊 Impact: Reduces intermediate object allocations inside the hot path, relieving GC pressure.

🔬 Measurement: Verifiable by running the engine tests (`./gradlew :shared:engine:testAndroidHostTest`) and profiling memory allocations during DMX effect rendering.

---
*PR created automatically by Jules for task [13560408851197163844](https://jules.google.com/task/13560408851197163844) started by @srMarlins*