### PR TITLE
🛡️ Sentinel: [HIGH] Secure mask of secrets in Jetpack Compose UI

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -442,6 +442,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                            keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Custom password/API Key text fields were susceptible to caching and auto-suggestions by OS input dictionaries.
* 🎯 Impact: API Keys or passwords could be learned by the mobile OS dictionary, leading to auto-suggestions in other fields or apps, inadvertently leaking secrets.
* 🔧 Fix: Added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to both `SettingsScreen` (API Key) and `ProvisioningScreen` (Wi-Fi Password) to explicitly instruct the system not to cache or suggest these values.
* ✅ Verification: Code compiles successfully. Text inputs verify using Compose standard security configurations.

---
*PR created automatically by Jules for task [10655972383541146657](https://jules.google.com/task/10655972383541146657) started by @srMarlins*