### PR TITLE
⚡ Bolt: Avoid Triple allocation in hsvToRgb

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,18 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: avoid Triple allocation in hot path
+        var r1 = 0f
+        var g1 = 0f
+        var b1 = 0f
+
+        when {
+            hue < 60f -> { r1 = c; g1 = x }
+            hue < 120f -> { r1 = x; g1 = c }
+            hue < 180f -> { g1 = c; b1 = x }
+            hue < 240f -> { g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; b1 = c }
+            else -> { r1 = c; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What**: Refactored `hsvToRgb` in `ColorUtils.kt` to avoid instantiating a `Triple` object when calculating color values.
🎯 **Why**: The `hsvToRgb` function is in the hot path of the effect engine, potentially running for every fixture every frame (60fps). Creating and destructuring short-lived `Triple` objects causes unnecessary heap allocations and garbage collection (GC) pressure, which can lead to micro-stutters.
📊 **Impact**: Reduces object allocations per frame per fixture in effects using HSV colors. This contributes to smoother DMX output by lessening GC overhead.
🔬 **Measurement**: Verified with existing unit tests in `:shared:engine` which all pass, ensuring RGB output remains exactly the same.

---
*PR created automatically by Jules for task [3568708413462801985](https://jules.google.com/task/3568708413462801985) started by @srMarlins*