### PR TITLE
🎨 Palette: [a11y] Use toggleable for PixelSwitch to announce state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-11 - Use toggleable for Switch accessibility
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` for switch components does not correctly announce their on/off state to screen readers.
+**Action:** Always use `Modifier.toggleable` instead of `Modifier.clickable` for switch components like `PixelSwitch` to ensure proper accessibility and screen reader support.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 What: Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable` in `PixelSwitch.kt`.
🎯 Why: In Compose Multiplatform, using `Modifier.clickable` with `Role.Switch` fails to provide the screen reader with the current `checked` state. Using `Modifier.toggleable` passes the explicit value and `onValueChange` action to the accessibility tree so screen readers correctly announce the on/off state.
📸 Before/After: Visuals are exactly the same, but talkback now correctly announces "on" and "off" instead of just acting as a simple button.
♿ Accessibility: Ensures correct state reading via TalkBack/VoiceOver for custom toggle components.

---
*PR created automatically by Jules for task [4828090514978176585](https://jules.google.com/task/4828090514978176585) started by @srMarlins*