### PR TITLE
🛡️ Sentinel: [security improvement] Disable keyboard caching for sensitive inputs

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -39,8 +39,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,11 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        // SECURITY: Disable dictionary caching and autocomplete for Wi-Fi password
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,11 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                // SECURITY: Disable dictionary caching and autocomplete for sensitive token
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Sensitive inputs (API keys and Wi-Fi passwords) were using `PasswordVisualTransformation` but lacked explicit keyboard configuration to disable autocorrect and caching. This allowed the OS dictionary or custom software keyboards to learn, cache, and potentially expose these secrets through predictive text.
🎯 **Impact:** If a user types their API key or Wi-Fi password, the OS could cache it. If someone else uses the same device, the predictive text might suggest the secret, leading to information leakage.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to both the API Key and Wi-Fi Password text fields. Added explanatory comments as requested by Sentinel guidelines.
✅ **Verification:** Ran module-specific lint and compile tasks (`:shared:engine:compileAndroidMain`, `:android:app:lintDebug`) and tests (`:shared:engine:testAndroidHostTest`) which all passed successfully. The changes are straightforward Compose modifiers.

---
*PR created automatically by Jules for task [6234775436289716708](https://jules.google.com/task/6234775436289716708) started by @srMarlins*