### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility with toggleable modifier

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - PixelSwitch Accessibility
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` on switch components correctly assigns the role but fails to announce the actual on/off state to screen readers in Compose Multiplatform.
+**Action:** Replaced `Modifier.clickable` with `Modifier.toggleable` on switch components to ensure their toggled state is properly exposed to the accessibility tree.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What:** Replaced `Modifier.clickable` with `Modifier.toggleable` in the `PixelSwitch` component.
🎯 **Why:** `Modifier.clickable` with `role = Role.Switch` tells a screen reader the element is a switch, but fails to actually communicate the current checked/unchecked state to the accessibility tree. `toggleable` correctly manages and exposes this boolean state.
♿ **Accessibility:** Screen readers will now correctly announce when a `PixelSwitch` is "On" or "Off".

---
*PR created automatically by Jules for task [83639901111904832](https://jules.google.com/task/83639901111904832) started by @srMarlins*