### PR TITLE
🛡️ Sentinel: [HIGH] Fix password caching in Settings & Provisioning Screen

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,7 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API keys and sensitive tokens in Compose UI forms did not disable `autoCorrectEnabled` while masking output using `PasswordVisualTransformation`.
🎯 Impact: Software keyboards (IMEs) may cache sensitive strings in their dictionaries and leak the values in autocomplete suggestions, violating secure state management.
🔧 Fix: Forcefully specify `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` onto the sensitive TextFields to restrict the OS-level keyboard behavior. 
✅ Verification: Ran `compileAndroidMain` to verify the codebase compiles successfully.

---
*PR created automatically by Jules for task [12994630232506036675](https://jules.google.com/task/12994630232506036675) started by @srMarlins*