### PR TITLE
🎨 Palette: Improve screen reader accessibility for PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-01 - Switch Component Accessibility in Compose Multiplatform
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` on custom switch components (like `PixelSwitch`) does not correctly announce their on/off state to screen readers (TalkBack/VoiceOver).
+**Action:** Always use `Modifier.toggleable` instead of `Modifier.clickable` for switch components to ensure their toggled state is properly exposed to accessibility services.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -54,12 +53,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
+            onValueChange = { onCheckedChange?.invoke(it) }
         )
         .let { mod ->
             if (checked && enabled) {


### PR DESCRIPTION
* 💡 **What**: Updated `PixelSwitch` to use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)`.
* 🎯 **Why**: In Compose Multiplatform, TalkBack and VoiceOver do not reliably announce the ON/OFF state of custom switch components built purely with `Modifier.clickable`. `Modifier.toggleable` inherently manages this semantic state.
* ♿ **Accessibility**: The switch component's toggled state is now properly exposed and announced to accessibility services. Also documented this insight in `.jules/palette.md`.

---
*PR created automatically by Jules for task [4208547006980643086](https://jules.google.com/task/4208547006980643086) started by @srMarlins*