### PR TITLE
🛡️ Sentinel: [HIGH] Fix autocomplete and OS dictionary caching on secret text fields

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -442,6 +442,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                            keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Wi-Fi password text fields used `PasswordVisualTransformation` but lacked `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)`. This omission causes device operating systems and third-party keyboard apps to cache, auto-correct, learn, and potentially leak the input plaintext.
🎯 Impact: Secrets could be leaked into the user's local dictionary, saved via clipboard managers, or exposed as autocomplete suggestions in other apps.
🔧 Fix: Updated `ProvisioningScreen.kt` and `SettingsScreen.kt` to explicitly set `keyboardType = KeyboardType.Password` and `autoCorrectEnabled = false` inside `KeyboardOptions`.
✅ Verification: Ran unit tests and compile tasks (`./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`). Verified that changes compile correctly with fully qualified package names.

---
*PR created automatically by Jules for task [16846953178439731022](https://jules.google.com/task/16846953178439731022) started by @srMarlins*