### PR TITLE
⚡ Bolt: Optimize ColorUtils allocations

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,17 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: Avoid Triple allocations in hot loop
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)
@@ -52,6 +56,13 @@ object ColorUtils {
         val hi = (lo + 1).coerceAtMost(maxIdx)
         val frac = scaled - lo
 
-        return palette[lo].lerp(palette[hi], frac)
+        // Optimization: inline lerp to avoid redundant coerceIn check since frac is 0..1
+        val c1 = palette[lo]
+        val c2 = palette[hi]
+        return Color(
+            c1.r + (c2.r - c1.r) * frac,
+            c1.g + (c2.g - c1.g) * frac,
+            c1.b + (c2.b - c1.b) * frac
+        )
     }
 }


### PR DESCRIPTION
💡 What: Optimized `hsvToRgb` and `samplePalette` in `ColorUtils.kt` by removing unnecessary `Triple` object allocations and inlining `lerp` calculation.
🎯 Why: In the DMX engine's rendering hot path, operations like `Triple` allocations or redundant `.coerceIn()` calls create thousands of intermediate objects per frame, leading to GC pauses and dropped frames.
📊 Impact: Reduces intermediate object allocations in the effect rendering hot path, improving framerate stability and reducing GC pressure.
🔬 Measurement: Verify changes by running `./gradlew :shared:engine:testAndroidHostTest`.

---
*PR created automatically by Jules for task [3144904007514604835](https://jules.google.com/task/3144904007514604835) started by @srMarlins*