### PR TITLE
🎨 Palette: Use toggleable for PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## $(date +%Y-%m-%d) - Switch Accessibility in Compose
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` for custom switch components only announces "Switch" but fails to announce the actual checked/unchecked state to TalkBack/VoiceOver natively.
+**Action:** Always use `Modifier.toggleable(value = checked, ... role = Role.Switch)` for binary toggle components to ensure correct state announcement in Compose Multiplatform.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,11 +4,11 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
**💡 What:**
Replaced `Modifier.clickable` with `Modifier.toggleable` in the custom `PixelSwitch` component.

**🎯 Why:**
Using `Modifier.clickable(role = Role.Switch)` tells a screen reader the element is a switch but fails to inherently track and announce its "checked" or "unchecked" state. Switching to `toggleable` natively wires up the `ToggleableState` so that TalkBack (Android) and VoiceOver (iOS) correctly announce state changes.

**📸 Before/After:**
*(Visuals remain identical. This is purely an accessibility tree update.)*

**♿ Accessibility:**
- Added robust screen reader state tracking for `PixelSwitch`.
- Users navigating via screen readers will now hear "Checked, Switch" or "Unchecked, Switch".

---
*PR created automatically by Jules for task [255864084991358086](https://jules.google.com/task/255864084991358086) started by @srMarlins*