### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix password input keyboard options to prevent dictionary caching

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrectEnabled = false,
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -743,6 +744,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false,
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** API Keys and Wi-Fi passwords were being entered into TextFields that masked the input (`PasswordVisualTransformation`), but did not instruct the OS keyboard that the input was a password. This causes mobile device keyboards (like Gboard or iOS keyboard) to learn and cache these sensitive strings in their predictive text dictionaries.
🎯 **Impact:** If a user types their API key, it is cached by the OS. The next time they type an unrelated message, the keyboard might suggest their API key, leading to accidental leakage or discovery by someone else using the device.
🔧 **Fix:** Added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to `SettingsScreen` and `ProvisioningScreen` password inputs to securely instruct the IME not to cache the input.
✅ **Verification:** Run the app on a device, navigate to settings, and type a fake API key. Observe that the keyboard does not attempt to autocorrect it and does not suggest it later. Verified via automated tests (`./gradlew :shared:compileAndroidMain`, `./gradlew :shared:testAndroidHostTest`).

---
*PR created automatically by Jules for task [2080417435055159767](https://jules.google.com/task/2080417435055159767) started by @srMarlins*