### PR TITLE
🛡️ Sentinel: [HIGH] Fix autocomplete on password/API key fields

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -442,6 +442,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                            keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Passwords and API keys entered into the `ProvisioningScreen` and `SettingsScreen` were using `PasswordVisualTransformation` to mask display text, but lacked the `KeyboardOptions` needed to tell the OS that the field was a password. This allows the OS to cache, learn, and autocorrect the sensitive values in the user's keyboard dictionary.
🎯 **Impact:** If a user types a Wi-Fi password or API key, their keyboard may save the literal string to their personal dictionary, leaking the secret on their device.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the `wifiPassword` field in `ProvisioningScreen.kt` and the `apiKey` field in `SettingsScreen.kt`.
✅ **Verification:** Verified by compiling the `shared` module successfully.

---
*PR created automatically by Jules for task [15483584314958512495](https://jules.google.com/task/15483584314958512495) started by @srMarlins*