### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility using toggleable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve PixelSwitch Accessibility for Screen Readers
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` for custom switch components does not consistently announce the "on/off" (checked/unchecked) state to screen readers.
+**Action:** Always use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)` for switch or toggle components to ensure their state is properly exposed to accessibility services.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**: Changed `Modifier.clickable(role = Role.Switch)` to `Modifier.toggleable` in `PixelSwitch.kt`. Added a journal entry about this learning in `.jules/palette.md`.
🎯 **Why**: In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` on custom switch components does not consistently announce the "checked/unchecked" state to screen readers correctly. `Modifier.toggleable` is the semantic standard for stateful on/off components and natively passes its state to accessibility services like TalkBack.
📸 **Before/After**: Visually identical.
♿ **Accessibility**: Massive improvement for screen reader users as the component now properly announces its state when focused or toggled.

---
*PR created automatically by Jules for task [8016548859186339831](https://jules.google.com/task/8016548859186339831) started by @srMarlins*