### PR TITLE
⚡ Bolt: Refactor ColorUtils.hsvToRgb to avoid Triple allocation

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,18 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: Use deferred assignment of primitive local variables
+        // instead of allocating a Triple object to prevent GC pauses in hot paths
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the `Triple` allocation in `ColorUtils.hsvToRgb` with deferred assignment of primitive `val` variables.
🎯 **Why:** `ColorUtils.hsvToRgb` is frequently called in the inner rendering loop, particularly for rainbow effects (`RainbowSweep3DEffect`). Returning a `Triple<Float, Float, Float>` from the `when` block forces the Kotlin compiler to auto-box the primitive floats into `java.lang.Float` objects and allocate a new `Triple` object on the heap for every color conversion, every frame.
📊 **Impact:** Reduces object allocations and garbage collection (GC) pressure by avoiding thousands of short-lived `Triple` objects per second when rendering high-frequency color effects, contributing to a more stable 60fps rendering pipeline.
🔬 **Measurement:** Verify by running the test suite (`./gradlew :shared:engine:testAndroidHostTest`). No functional changes; only performance improvements.

---
*PR created automatically by Jules for task [3618141714727473983](https://jules.google.com/task/3618141714727473983) started by @srMarlins*