### PR TITLE
⚡ Bolt: Eliminate Triple allocation in hsvToRgb

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,19 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: Use deferred assignment of primitive val variables instead of
+        // returning a Triple from the when block. This eliminates a temporary Triple
+        // object allocation per pixel per frame when evaluating HSV-based effects.
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Eliminated a temporary `Triple` object allocation in `ColorUtils.hsvToRgb`.
🎯 **Why:** The DMX engine evaluates colors in a hot path (e.g., per-pixel, per-frame). When effects use HSV colors, the `hsvToRgb` function was allocating a `Triple` object via the exhaustive `when` block, causing memory churn and GC pauses.
📊 **Impact:** Reduces object allocations by 1 object per pixel per frame for HSV-based effects, improving GC performance and maintaining frame rates.
🔬 **Measurement:** Code verified to compile and run tests successfully using `./gradlew :shared:engine:testAndroidHostTest`. Object allocation profile should show zero `Triple` allocations from this method.

---
*PR created automatically by Jules for task [8550414272994656634](https://jules.google.com/task/8550414272994656634) started by @srMarlins*