### PR TITLE
🎨 Palette: Fix PixelSwitch accessibility by using toggleable

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,11 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            value = checked, onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What:** 
Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable` in the `PixelSwitch` component.

🎯 **Why:** 
When using a simple `clickable` modifier with a switch role, Compose does not automatically convey the underlying `checked` state to accessibility services (like Android TalkBack). Using `toggleable` is the correct semantic modifier for checkboxes and switches, allowing screen readers to accurately announce "On" or "Off".

📸 **Before/After:**
Visuals remain identical.

♿ **Accessibility:** 
TalkBack and other screen reading tools will now properly announce the current state of the switch to users.

---
*PR created automatically by Jules for task [1518902789336003742](https://jules.google.com/task/1518902789336003742) started by @srMarlins*