### PR TITLE
🛡️ Sentinel: [HIGH] Fix password caching/autocomplete in text fields

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -41,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -744,6 +744,10 @@ private fun AgentSection(
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
                 modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
             )
 
             // Model selector


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Sensitive tokens like API keys and Wi-Fi passwords were being typed using the default keyboard type. This could allow the OS to learn and cache these secrets in the user's personal dictionary for future auto-correction.
🎯 **Impact:** Potential leakage of secrets to device-level dictionary storage, which might be synced to the cloud or surfaced in text predictions elsewhere.
🔧 **Fix:** Added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the password text fields to explicitly instruct the system keyboard not to cache the input.
✅ **Verification:** Compiled the code via `./gradlew :shared:compileAndroidMain` and ran unit tests. The fields will now properly instruct the system keyboard not to offer autocomplete or learn the typed words.

---
*PR created automatically by Jules for task [1421221345581200680](https://jules.google.com/task/1421221345581200680) started by @srMarlins*