### PR TITLE
🎨 Palette: Add semantic roles to interactive components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-17 - Add semantic roles to interactive components
+**Learning:** Custom interactive components using raw `Modifier.clickable` are not announced as buttons to screen readers without an explicit semantic role.
+**Action:** Always set `role = Role.Button` (or the appropriate role) in `Modifier.clickable` for interactive controls to ensure they are accessible.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
@@ -46,7 +46,10 @@ fun NodeHealthCompact(
 
     Row(
         modifier = modifier
-            .clickable { onClick() }
+            .clickable(
+                onClick = onClick,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
@@ -54,7 +54,10 @@ fun SimulationBadge(
     Box(
         modifier = modifier
             .alpha(alpha)
-            .clickable(onClick = onTap)
+            .clickable(
+                onClick = onTap,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .pixelBorder(color = NeonMagenta.copy(alpha = 0.6f), pixelSize = pixelSize)
             .background(NeonMagenta.copy(alpha = 0.25f))
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
@@ -76,6 +76,7 @@ fun BpmDisplay(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onTap,
+                role = androidx.compose.ui.semantics.Role.Button,
             )
             .padding(horizontal = 4.dp, vertical = 4.dp),
         contentAlignment = Alignment.Center,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
@@ -48,7 +48,10 @@ fun NodeHealthBar(
 
     Row(
         modifier = modifier
-            .clickable(onClick = onExpand)
+            .clickable(
+                onClick = onExpand,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
💡 What: Added semantic `Role.Button` to raw `Modifier.clickable` components.
🎯 Why: To ensure screen readers announce these interactive elements correctly as buttons.
📸 Before/After: Visuals remained identical.
♿ Accessibility: Ensures correct component identification in a11y tree.

---
*PR created automatically by Jules for task [1491259094958122958](https://jules.google.com/task/1491259094958122958) started by @srMarlins*