### PR TITLE
🛡️ Sentinel: [HIGH] Fix PasswordVisualTransformation leaking secrets

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,7 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix leaking secrets in PasswordVisualTransformation

Severity: HIGH
Vulnerability: Sensitive tokens and passwords can be leaked to OS dictionary and autocomplete when not configured properly with KeyboardOptions.
Impact: Passwords/Secrets could be suggested or saved by the OS dictionary caching.
Fix: Add `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to PixelTextField and OutlinedTextField handling passwords.
Verification: UI text fields no longer suggest OS dictionary caching or auto-correct when typing.

---
*PR created automatically by Jules for task [18063881205294646023](https://jules.google.com/task/18063881205294646023) started by @srMarlins*