### PR TITLE
⚡ Bolt: Avoid Triple allocation in ColorUtils.hsvToRgb

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,18 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: prevent Triple allocations and primitive boxing per color conversion
+        val r1: Float
+        val g1: Float
+        val b1: Float
+
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 What: Removed `Triple` object allocation from `ColorUtils.hsvToRgb` by utilizing deferred initialization of primitive local `val`s.
🎯 Why: `hsvToRgb` is frequently called in rendering hot paths (e.g. `RainbowSweep3DEffect`). The previous implementation instantiated a `Triple` for every color conversion and forced auto-boxing of the primitives (e.g. `java.lang.Float` on the JVM). This optimization prevents those allocations to decrease GC pauses.
📊 Impact: Saves one object allocation and three primitive boxings per color conversion, which can add up to thousands of allocations saved per frame depending on the complexity of the effect stack.
🔬 Measurement: Run the engine unit tests (`./gradlew :shared:engine:testAndroidHostTest`) and observe no functional regressions. Profile engine memory allocations during typical playback to observe the drop in `Triple` creations.

---
*PR created automatically by Jules for task [3515997678682035703](https://jules.google.com/task/3515997678682035703) started by @srMarlins*