### PR TITLE
🛡️ Sentinel: [HIGH] Secure password inputs from OS caching

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,7 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Wi-Fi password input fields allowed OS keyboards to cache and autocomplete entered values.
🎯 Impact: Sensitive user data such as the API Key and Wi-Fi password could be learned by the device's keyboard or third-party keyboards, causing the values to be inadvertently leaked.
🔧 Fix: Updated `SettingsScreen.kt` and `ProvisioningScreen.kt` `PixelTextField` instances bound to `apiKey` and `wifiPassword` to explicitly include `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)`.
✅ Verification: Ran UI compilation (`./gradlew :shared:compileAndroidMain`) and UI-specific tests to confirm no regressions.

---
*PR created automatically by Jules for task [11415778692127757617](https://jules.google.com/task/11415778692127757617) started by @srMarlins*