### PR TITLE
⚡ Bolt: Reduce GC allocations in BlobDetector by merging filter and map

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-10 - Avoid Chained Collection Operations in Hot Paths
+**Learning:** In the `BlobDetector` computer vision hot path, chaining `.filter { ... }.map { ... }` on collections causes unnecessary intermediate object allocations, adding GC pressure during per-frame processing.
+**Action:** Always combine filtering and mapping into a single `.mapNotNull { if (condition) result else null }` to traverse the collection exactly once and avoid the intermediate collection allocation.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -63,16 +63,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }


### PR DESCRIPTION
🎯 **What:** Optimized the collection chain `.filter { ... }.map { ... }` into a single `.mapNotNull { ... }` block in `BlobDetector.kt`.
💡 **Why:** In the `BlobDetector` computer vision hot path, chaining collection operations causes unnecessary intermediate `ArrayList` object allocations, increasing GC pressure during per-frame processing.
📊 **Impact:** Reduces object allocations by combining filtering and mapping logic to traverse the collection exactly once. This avoids the intermediate collection allocation.
🔬 **Measurement:** Verify by ensuring `shared/vision` tests pass and by profiling GC activity in the computer vision loop. All tests ran locally pass successfully.

---
*PR created automatically by Jules for task [9616094339713953151](https://jules.google.com/task/9616094339713953151) started by @srMarlins*