### PR TITLE
🎨 Palette: [Accessibility] Improve PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-03-02 - PixelSwitch Accessibility
+**Learning:** `Modifier.clickable(role = Role.Switch)` with an `onClick` parameter on a custom toggle switch component does not correctly convey the "toggle" semantics to screen readers on Compose Multiplatform, resulting in suboptimal accessibility.
+**Action:** Used `Modifier.toggleable(value = checked, role = Role.Switch, onValueChange = ...)` instead, which specifically provides the current toggle state to semantics trees and appropriately handles the state mutation.

--- a/patch_switch.sh
+++ b/patch_switch.sh
@@ -1,0 +1,3 @@
+sed -i 's/import androidx.compose.foundation.clickable/import androidx.compose.foundation.selection.toggleable/' shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+sed -i 's/\.clickable(/.toggleable(\n            value = checked,/' shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+sed -i 's/onClick = { onCheckedChange?.invoke(!checked) }/onValueChange = { onCheckedChange?.invoke(it) }/' shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
- **What:** Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(value = checked, role = Role.Switch)` in `PixelSwitch`.
- **Why:** In Compose Multiplatform, using `Modifier.clickable` with a switch role doesn't correctly inform screen readers (like TalkBack) about the current toggled state of the switch. `Modifier.toggleable` natively understands and broadcasts the checked state, making the component much more usable for visually impaired users.
- **Before/After:** No visual changes, only semantic changes for assistive technologies.
- **Accessibility:** Direct improvement to screen reader support by correctly announcing the on/off state of the custom switch component.

---
*PR created automatically by Jules for task [16116517961640010454](https://jules.google.com/task/16116517961640010454) started by @srMarlins*