### PR TITLE
🛡️ Sentinel: [HIGH] Secure Masking of Secrets in Jetpack Compose UI

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -54,6 +54,8 @@ import com.chromadmx.ui.components.PixelProgressBar
 import com.chromadmx.ui.theme.NeonCyan
 import com.chromadmx.ui.theme.NeonGreen
 import com.chromadmx.ui.viewmodel.ProvisioningViewModel
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 
 @Composable
 fun ProvisioningScreen(
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -744,6 +744,7 @@ private fun AgentSection(
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
                 modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
             )
 
             // Model selector


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Sensitive text fields like `wifiPassword` (in `ProvisioningScreen.kt`) and `apiKey` (in `SettingsScreen.kt`) used `PasswordVisualTransformation` but lacked proper `KeyboardOptions`. This meant that the OS dictionary could cache these secrets and offer them via autocomplete, leaking sensitive tokens.
🎯 **Impact:** Exposes Wi-Fi passwords and API keys to the OS's autocomplete database, potentially exposing them to other applications or users.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to both text fields to instruct the OS keyboard to disable autocomplete and caching for these inputs.
✅ **Verification:** Verified via `./gradlew :shared:compileAndroidMain` and ensured there are no new failing tests via `./gradlew :shared:core:testAndroidHostTest`. Simulated a visual frontend verification.

---
*PR created automatically by Jules for task [17328688460294636363](https://jules.google.com/task/17328688460294636363) started by @srMarlins*