### PR TITLE
🎨 Palette: Add semantic button roles to interactive UI components

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
@@ -46,7 +46,10 @@ fun NodeHealthCompact(
 
     Row(
         modifier = modifier
-            .clickable { onClick() }
+            .clickable(
+                onClick = onClick,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
@@ -54,7 +54,10 @@ fun SimulationBadge(
     Box(
         modifier = modifier
             .alpha(alpha)
-            .clickable(onClick = onTap)
+            .clickable(
+                onClick = onTap,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .pixelBorder(color = NeonMagenta.copy(alpha = 0.6f), pixelSize = pixelSize)
             .background(NeonMagenta.copy(alpha = 0.25f))
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
@@ -76,6 +76,7 @@ fun BpmDisplay(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onTap,
+                role = androidx.compose.ui.semantics.Role.Button,
             )
             .padding(horizontal = 4.dp, vertical = 4.dp),
         contentAlignment = Alignment.Center,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
@@ -48,7 +48,10 @@ fun NodeHealthBar(
 
     Row(
         modifier = modifier
-            .clickable(onClick = onExpand)
+            .clickable(
+                onClick = onExpand,
+                role = androidx.compose.ui.semantics.Role.Button,
+            )
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
🎯 **What:**
Added `role = Role.Button` to the `Modifier.clickable()` instances in several custom interactive components: `SimulationBadge`, `NodeHealthCompact`, `BpmDisplay`, and `NodeHealthBar`.

🎯 **Why:**
Without an explicit role, screen readers (like Android's TalkBack or iOS's VoiceOver) treat these elements merely as generic text or groups, making it unclear to users relying on assistive technologies that these elements are interactive buttons that perform an action when tapped. By explicitly assigning `Role.Button`, screen readers will correctly announce them as buttons (e.g., "SIMULATION, Button, Double-tap to activate").

📸 **Before/After:**
- *Before*: Screen readers announced simply "SIMULATION" or "100".
- *After*: Screen readers announce "SIMULATION, Button" or "100, Button".

♿ **Accessibility:**
Directly improves keyboard navigation and screen reader support for critical navigation, network health, and timing controls in the app.

---
*PR created automatically by Jules for task [11685137708692578499](https://jules.google.com/task/11685137708692578499) started by @srMarlins*