### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility with toggleable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve Switch component accessibility with Modifier.toggleable
+**Learning:** In Compose Multiplatform, using `Modifier.clickable` with `role = Role.Switch` for switch components does not correctly announce their on/off state to screen readers.
+**Action:** Always use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)` for switch components to correctly announce their on/off state to screen readers.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**: Changed `Modifier.clickable` + `Role.Switch` to `Modifier.toggleable` in `PixelSwitch`.
🎯 **Why**: In Compose Multiplatform, using `clickable` with a switch role does not correctly announce the component's checked state changes to screen readers. `toggleable` is specifically designed for boolean-state controls and provides correct semantic information to assistive technologies.
📸 **Before/After**: Visually identical. Under-the-hood improvement for TalkBack/VoiceOver.
♿ **Accessibility**: Screen readers will now correctly announce when the switch is toggled "On" or "Off".

---
*PR created automatically by Jules for task [3064651379221850387](https://jules.google.com/task/3064651379221850387) started by @srMarlins*