### PR TITLE
🛡️ Sentinel: [HIGH] Prevent OS dictionary caching for sensitive fields

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -442,6 +442,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                            keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Sensitive text fields (`PixelTextField` for API Key, `OutlinedTextField` for Wi-Fi Password) lacked `KeyboardOptions` configured with `KeyboardType.Password` and `autoCorrectEnabled = false`. This omission could cause the OS keyboard to cache these sensitive values in its dictionary and offer them via autocomplete suggestions.
🎯 **Impact:** If an attacker gains access to the device or if the device is shared, autocomplete could suggest the API key or Wi-Fi password in other applications or text fields, leading to credential leakage.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the relevant fields in `SettingsScreen.kt` and `ProvisioningScreen.kt`.
✅ **Verification:** Compiled the application and verified that the changes do not introduce compilation errors. Simulated test flows function correctly. Tested with `./gradlew :shared:compileAndroidMain` and `./gradlew :shared:lint`.

---
*PR created automatically by Jules for task [9577130407352335069](https://jules.google.com/task/9577130407352335069) started by @srMarlins*