### PR TITLE
🎨 Palette: [accessibility improvement] Use toggleable for PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Accessibility Improvement for PixelSwitch
+**Learning:** `Modifier.clickable` with `role = Role.Switch` does not announce the on/off state to screen readers correctly in Compose Multiplatform.
+**Action:** Use `Modifier.toggleable` instead for switch components like `PixelSwitch` to correctly announce their state to screen readers.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +54,18 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else mod
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.NeonMagenta
@@ -54,7 +55,7 @@ fun SimulationBadge(
     Box(
         modifier = modifier
             .alpha(alpha)
-            .clickable(onClick = onTap)
+            .clickable(onClick = onTap, role = Role.Button)
             .pixelBorder(color = NeonMagenta.copy(alpha = 0.6f), pixelSize = pixelSize)
             .background(NeonMagenta.copy(alpha = 0.25f))
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/beat/BpmDisplay.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.chromadmx.ui.theme.PixelDesign
@@ -76,6 +77,7 @@ fun BpmDisplay(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onTap,
+                role = Role.Button,
             )
             .padding(horizontal = 4.dp, vertical = 4.dp),
         contentAlignment = Alignment.Center,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/network/NodeHealthBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.PixelDesign
 import com.chromadmx.ui.theme.PixelFontFamily
@@ -48,7 +49,7 @@ fun NodeHealthBar(
 
     Row(
         modifier = modifier
-            .clickable(onClick = onExpand)
+            .clickable(onClick = onExpand, role = Role.Button)
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
💡 What:
Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable` in `PixelSwitch.kt`. Added explicit `role = Role.Button` to `Modifier.clickable` in `SimulationBadge.kt`, `BpmDisplay.kt`, and `NodeHealthBar.kt`.

🎯 Why:
`Modifier.clickable` with a switch role does not correctly announce its on/off state to screen readers in Compose Multiplatform, causing accessibility issues. Similarly, interactive elements without explicit roles are harder for screen reader users to understand.

📸 Before/After: N/A - The visual appearance remains exactly the same, but the screen reader experience is improved.

♿ Accessibility:
- Screen readers will now announce "checked" or "not checked" for `PixelSwitch`.
- `SimulationBadge`, `BpmDisplay`, and `NodeHealthBar` will be correctly identified as buttons by screen readers.

---
*PR created automatically by Jules for task [684698994839239801](https://jules.google.com/task/684698994839239801) started by @srMarlins*