### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility for screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-14 - Compose Switch Accessibility with Modifier.toggleable
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` for switch components (like `PixelSwitch`) is insufficient for screen readers. It fails to correctly announce the "on/off" or "checked/unchecked" state of the switch because `clickable` does not manage a binary value.
+**Action:** Always use `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)` for switch or checkbox-like components. `Modifier.toggleable` intrinsically handles the `value: Boolean` state and correctly interfaces with the semantics tree to announce state changes to screen readers (like TalkBack or VoiceOver).

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What:** Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable` on the `PixelSwitch` component.
🎯 **Why:** `Modifier.clickable` does not manage binary state natively, meaning screen readers won't announce "checked" or "unchecked". Using `Modifier.toggleable` intrinsically handles the `value` state and correctly updates the Compose semantics tree, allowing tools like TalkBack or VoiceOver to interact properly.
♿ **Accessibility:** Screen readers can now correctly read and update the on/off state of switches across the app.
📓 **Journal:** Added an entry to `.jules/palette.md` to document this accessibility learning for Compose Multiplatform.

---
*PR created automatically by Jules for task [15330763400848019407](https://jules.google.com/task/15330763400848019407) started by @srMarlins*