### PR TITLE
⚡ Bolt: [performance improvement] avoid Triple allocation in ColorUtils.hsvToRgb

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Avoid Triple/Pair Allocations in Exhaustive When Blocks
+**Learning:** Returning `Triple` or `Pair` from an exhaustive `when` block in hot paths (like `ColorUtils.hsvToRgb`) forces object allocations and primitive auto-boxing on every execution, adding up to thousands of allocations per frame and causing GC pressure.
+**Action:** Use deferred `val` assignments for primitive variables (e.g., `val r1: Float; when { ... -> r1 = val }`) instead of returning and destructuring utility objects in performance-critical code.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,18 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        // Optimization: use deferred assignment for primitive variables
+        // instead of returning a Triple to avoid object allocation and auto-boxing in this hot path
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the exhaustive `when` block returning a `Triple` with deferred primitive `val` assignments in `ColorUtils.hsvToRgb()`.
🎯 **Why:** `Triple` creates a heap allocation and forces auto-boxing of `Float` values. When `hsvToRgb` is called by effects in the engine hot loop (60+ times per second per fixture), this causes significant GC pressure.
📊 **Impact:** Reduces object allocations by exactly 1 object (`Triple`) and 3 primitive boxes (`Float`) per call. Eliminates thousands of object allocations per frame in high-fixture scenarios.
🔬 **Measurement:** Verify by running a heap profiler on the Android host with complex active effects. GC pause frequency should noticeably decrease.

---
*PR created automatically by Jules for task [8917170279410409992](https://jules.google.com/task/8917170279410409992) started by @srMarlins*