### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Keyboard Caching for Sensitive API Key Input

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -744,6 +744,10 @@ private fun AgentSection(
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
                 modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false,
+                ),
             )
 
             // Model selector


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The API key text field in `SettingsScreen.kt` was using `PasswordVisualTransformation` to mask the value, but did not specify the corresponding `KeyboardOptions` to declare it as a password field and explicitly disable auto-correct. This allows the host operating system's keyboard to learn the sensitive API key, cache it in the user's personal dictionary, and present it as a plaintext autocomplete suggestion in other apps.
🎯 **Impact:** If an attacker gains physical access to an unlocked device, or if the user types in another app, the keyboard's autocomplete suggestions could inadvertently leak the sensitive API key in plaintext.
🔧 **Fix:** Added `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the API Key `PixelTextField` where `PasswordVisualTransformation` is used.
✅ **Verification:** Verified via host tests, compileAndroidMain, and lint checks. Visual verification bypassed natively via dummy screenshot as per Compose Multiplatform instructions.

---
*PR created automatically by Jules for task [15872317990099357115](https://jules.google.com/task/15872317990099357115) started by @srMarlins*