### PR TITLE
⚡ Bolt: Avoid intermediate Triple allocations in hsvToRgb

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,16 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the `Triple<Float, Float, Float>` allocation in the `ColorUtils.hsvToRgb` function's `when` block with deferred primitive variable assignments (`r1`, `g1`, `b1`).

🎯 **Why:** The `hsvToRgb` function is often called in tight rendering loops (hot paths) within the DMX engine. The previous implementation allocated a new `Triple` object for every evaluation, leading to excessive primitive auto-boxing (`Float` to `java.lang.Float`), increased memory footprint, and unnecessary Garbage Collection (GC) pauses. 

📊 **Impact:** This optimization eliminates a significant source of object allocations per frame without changing the core math logic, preserving framerates and providing a smoother DMX engine render cycle.

🔬 **Measurement:** Verify by running the DMX engine while profiling memory allocations; the number of `Triple` instances and `java.lang.Float` instances generated during `hsvToRgb` calls should be zero.

---
*PR created automatically by Jules for task [17263421075943159132](https://jules.google.com/task/17263421075943159132) started by @srMarlins*