### PR TITLE
⚡ Bolt: [performance improvement] Optimize ColorUtils hot paths

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,16 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)
@@ -52,6 +55,13 @@ object ColorUtils {
         val hi = (lo + 1).coerceAtMost(maxIdx)
         val frac = scaled - lo
 
-        return palette[lo].lerp(palette[hi], frac)
+        val c1 = palette[lo]
+        val c2 = palette[hi]
+
+        return Color(
+            c1.r + (c2.r - c1.r) * frac,
+            c1.g + (c2.g - c1.g) * frac,
+            c1.b + (c2.b - c1.b) * frac
+        )
     }
 }


### PR DESCRIPTION
💡 What: Optimized `hsvToRgb` to use primitive variables instead of `Triple`, and inlined `samplePalette` math to bypass `Color.lerp()` object bounds checking.
🎯 Why: `Triple<Float, Float, Float>` causes auto-boxing of primitives to `java.lang.Float` inside the rendering inner loop. This creates severe garbage collection pressure (4 extra objects per pixel conversion). 
📊 Impact: Eliminates primitive boxing and object creation inside `hsvToRgb`, significantly reducing GC pauses and improving framerate during color processing.
🔬 Measurement: Verify via `./gradlew :shared:engine:testAndroidHostTest`. Run Android Studio Profiler during effect playback to observe reduced object allocation rate.

---
*PR created automatically by Jules for task [14713259010042186154](https://jules.google.com/task/14713259010042186154) started by @srMarlins*