### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility with toggleable

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**: Replaced `Modifier.clickable` with `Modifier.toggleable` in `PixelSwitch.kt`.
🎯 **Why**: Using `clickable` with `Role.Switch` marks the component as a switch, but it does *not* announce its current state (On/Off) to screen readers. `toggleable` explicitly handles both the role and the checked state, ensuring complete accessibility support.
📸 **Before/After**: N/A (Internal semantics change, visual appearance is identical)
♿ **Accessibility**: Screen readers (like TalkBack) will now properly read "Switch, On" or "Switch, Off" instead of just "Switch" when interacting with the `PixelSwitch` component.

---
*PR created automatically by Jules for task [5317682161278657839](https://jules.google.com/task/5317682161278657839) started by @srMarlins*