### PR TITLE
🛡️ Sentinel: [HIGH] Fix secure masking and keyboard options for secrets

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -442,6 +444,10 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            autoCorrectEnabled = false
+                        ),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,10 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    autoCorrectEnabled = false
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** TextFields handling sensitive secrets (API Key and Wi-Fi Password) lacked appropriate `KeyboardOptions` to declare `keyboardType = KeyboardType.Password` and `autoCorrectEnabled = false`. This risks exposing secrets to the OS dictionary cache, prediction algorithms, and autocomplete services.
🎯 **Impact:** If exploited or leaked via dictionary, user's private LLM API Keys or Wi-Fi Passwords could be compromised.
🔧 **Fix:** Explicitly set `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` on these specific `OutlinedTextField` and `PixelTextField` instances to instruct the OS to treat input as a secret and disable caching/autocorrect.
✅ **Verification:** Compiled `:shared:compileAndroidMain` and ran tests. Visually verified the UI fields.

---
*PR created automatically by Jules for task [12402995214851204554](https://jules.google.com/task/12402995214851204554) started by @srMarlins*