### PR TITLE
🎨 Palette: [UX improvement] Fix Switch Accessibility Semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-03-08 - Switch Accessibility Semantics
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` tells the screen reader it is a switch but fails to announce its current "On" or "Off" value.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switch components to properly set the semantics for both the role and its current state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +55,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What:** Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(value = checked, ...)` inside `PixelSwitch`.
🎯 **Why:** In Compose Multiplatform, using `clickable` combined with `Role.Switch` simply identifies the element as a switch to TalkBack/VoiceOver, but it does *not* announce whether the switch is currently on or off.
📸 **Before/After:** The visual state is identical. Semantically, screen readers now append "On" or "Off" instead of just announcing "Switch".
♿ **Accessibility:** This directly addresses an issue preventing visually impaired users from determining the current boolean state of any pixelated switch component within the app.

---
*PR created automatically by Jules for task [2806809543310678945](https://jules.google.com/task/2806809543310678945) started by @srMarlins*