### PR TITLE
⚡ Bolt: Use mapNotNull in BlobDetector to reduce allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Avoid Chained Collection Operations in Hot Paths
+**Learning:** In performance-critical hot paths like the vision module's BlobDetector, chaining `.filter { ... }.map { ... }` on collections creates intermediate collections, leading to unnecessary GC pressure and CPU cycles.
+**Action:** Use `.mapNotNull { if (condition) result else null }` to combine filtering and mapping into a single traversal with fewer object allocations.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -63,16 +63,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }


### PR DESCRIPTION
💡 What: Replaced chained `.filter { ... }.map { ... }` with a single `.mapNotNull { ... }` in `BlobDetector.kt`.
🎯 Why: In a performance-critical vision processing hot path, chaining standard collection operations creates unnecessary intermediate `ArrayList` allocations and redundant list iterations. This increases Garbage Collection (GC) pressure and CPU cycle usage.
📊 Impact: Eliminates an intermediate list allocation and a redundant iteration per frame processing, reducing GC pressure and marginally improving execution speed for vision detection.
🔬 Measurement: Verify compilation and tests via `./gradlew :shared:vision:compileAndroidMain` and `./gradlew :shared:vision:testAndroidHostTest`.

---
*PR created automatically by Jules for task [10636493888945315904](https://jules.google.com/task/10636493888945315904) started by @srMarlins*