### PR TITLE
🎨 Palette: Use toggleable for PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-19 - Use toggleable instead of clickable for custom Switch components
+**Learning:** `Modifier.clickable(role = Role.Switch)` tells the screen reader it is a switch but does NOT announce the current "On" or "Off" state of the checked property, making it inaccessible.
+**Action:** Use `Modifier.toggleable(value = checked, ...)` instead when building custom switch or checkbox components in Compose. This properly associates the semantics for both the role and the boolean value state.

--- a/lint_out.txt
+++ b/lint_out.txt
@@ -1,0 +1,285 @@
+Downloading https://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+.............10%.............20%.............30%.............40%.............50%.............60%.............70%.............80%.............90%.............100%
+
+Welcome to Gradle 9.3.1!
+
+Here are the highlights of this release:
+ - Test reporting improvements
+ - Error and warning improvements
+ - Build authoring improvements
+
+For more details see https://docs.gradle.org/9.3.1/release-notes.html
+
+Starting a Gradle Daemon (subsequent builds will be faster)
+> Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :build-logic:convention:pluginDescriptors
+> Task :build-logic:convention:processResources
+> Task :build-logic:convention:compileKotlin
+> Task :build-logic:convention:compileJava NO-SOURCE
+> Task :build-logic:convention:classes
+> Task :build-logic:convention:jar
+
+> Configure project :shared:tempo
+w: file:///app/shared/tempo/build.gradle.kts:15:17: 'var defFile: File' is deprecated. Deprecated because it is a non-lazy property.
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosX64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosX64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosSimulatorArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosSimulatorArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ CInterop Commonization Disabled[0m[0m
+The project is using Kotlin Multiplatform with hierarchical structure and disabled 'cinterop commonization'
+
+'cinterop commonization' can be enabled in your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization=true
+
+To hide this message, add to your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization.nowarn=true
+
+The following source sets are affected:
+[appleMain, iosMain, nativeMain]
+
+The following cinterops are affected:
+[cinterop:compilation/compileKotlinIosArm64/abletonLink, cinterop:compilation/compileKotlinIosSimulatorArm64/abletonLink, cinterop:compilation/compileKotlinIosX64/abletonLink]
+[32m[1mSolution:[0m[0m
+[32m[3mPlease enable 'cinterop commonization' in your 'gradle.properties'[0m[0m
+[36mSee: [0m[34mhttps://kotlinlang.org/docs/mpp-share-on-platforms.html#use-native-libraries-in-the-hierarchical-structure[0m[36m[0m
+
+Checking the license for package Android SDK Build-Tools 36 in /opt/android-sdk/licenses
+License for package Android SDK Build-Tools 36 accepted.
+Preparing "Install Android SDK Build-Tools 36 v.36.0.0".
+"Install Android SDK Build-Tools 36 v.36.0.0" ready.
+Installing Android SDK Build-Tools 36 in /opt/android-sdk/build-tools/36.0.0
+"Install Android SDK Build-Tools 36 v.36.0.0" complete.
+"Install Android SDK Build-Tools 36 v.36.0.0" finished.
+[=========                              ] 25%
+> Task :shared:convertXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
+> Task :shared:generateResourceAccessorsForAndroidMain NO-SOURCE
+> Task :shared:convertXmlValueResourcesForCommonMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForCommonMain
+> Task :shared:prepareComposeResourcesTaskForCommonMain
+> Task :shared:generateResourceAccessorsForCommonMain
+> Task :shared:androidPreBuild UP-TO-DATE
+> Task :shared:preAndroidMainBuild UP-TO-DATE
+> Task :shared:agent:androidPreBuild UP-TO-DATE
+> Task :shared:agent:preAndroidMainBuild UP-TO-DATE
+> Task :shared:core:androidPreBuild UP-TO-DATE
+> Task :shared:core:preAndroidMainBuild UP-TO-DATE
+> Task :shared:agent:writeAndroidMainAarMetadata
+> Task :shared:engine:androidPreBuild UP-TO-DATE
+> Task :shared:engine:preAndroidMainBuild UP-TO-DATE
+> Task :shared:core:writeAndroidMainAarMetadata
+> Task :shared:networking:androidPreBuild UP-TO-DATE
+> Task :shared:engine:writeAndroidMainAarMetadata
+> Task :shared:networking:preAndroidMainBuild UP-TO-DATE
+> Task :shared:simulation:androidPreBuild UP-TO-DATE
+> Task :shared:simulation:preAndroidMainBuild UP-TO-DATE
+> Task :shared:networking:writeAndroidMainAarMetadata
+> Task :shared:simulation:writeAndroidMainAarMetadata
+> Task :shared:subscription:androidPreBuild UP-TO-DATE
+> Task :shared:subscription:preAndroidMainBuild UP-TO-DATE
+> Task :shared:tempo:androidPreBuild UP-TO-DATE
+> Task :shared:tempo:preAndroidMainBuild UP-TO-DATE
+> Task :shared:subscription:writeAndroidMainAarMetadata
+> Task :shared:vision:androidPreBuild UP-TO-DATE
+> Task :shared:vision:preAndroidMainBuild UP-TO-DATE
+> Task :shared:tempo:writeAndroidMainAarMetadata
+> Task :shared:wled:androidPreBuild UP-TO-DATE
+> Task :shared:wled:preAndroidMainBuild UP-TO-DATE
+> Task :shared:vision:writeAndroidMainAarMetadata
+> Task :shared:wled:writeAndroidMainAarMetadata
+> Task :shared:agent:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:checkAndroidMainAarMetadata
+> Task :shared:agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:core:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:core:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:engine:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:engine:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:tempo:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:tempo:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:networking:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:networking:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:wled:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:wled:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:simulation:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:simulation:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:vision:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:vision:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:subscription:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:subscription:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:generateAndroidMainEmptyResourceFiles
+> Task :shared:processAndroidMainManifest
+> Task :shared:core:generateCommonMainChromaDmxDatabaseInterface
+> Task :shared:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:core:compileAndroidMain
+> Task :shared:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:generateActualResourceCollectorsForAndroidMain
+> Task :shared:generateComposeResClass
+> Task :shared:generateExpectResourceCollectorsForCommonMain
+> Task :shared:writeAndroidMainAarMetadata
+> Task :shared:agent:checkAndroidMainAarMetadata
+> Task :shared:agent:generateAndroidMainEmptyResourceFiles
+> Task :shared:agent:processAndroidMainManifest
+> Task :shared:engine:checkAndroidMainAarMetadata
+> Task :shared:engine:generateAndroidMainEmptyResourceFiles
+> Task :shared:engine:processAndroidMainManifest
+> Task :shared:simulation:checkAndroidMainAarMetadata
+> Task :shared:simulation:generateAndroidMainEmptyResourceFiles
+> Task :shared:simulation:processAndroidMainManifest
+> Task :shared:wled:checkAndroidMainAarMetadata
+> Task :shared:wled:generateAndroidMainEmptyResourceFiles
+> Task :shared:wled:processAndroidMainManifest
+> Task :shared:networking:checkAndroidMainAarMetadata
+> Task :shared:networking:generateAndroidMainEmptyResourceFiles
+> Task :shared:tempo:checkAndroidMainAarMetadata
+> Task :shared:networking:processAndroidMainManifest
+> Task :shared:tempo:generateAndroidMainEmptyResourceFiles
+> Task :shared:tempo:processAndroidMainManifest
+> Task :shared:subscription:checkAndroidMainAarMetadata
+> Task :shared:subscription:generateAndroidMainEmptyResourceFiles
+> Task :shared:subscription:processAndroidMainManifest
+> Task :shared:vision:checkAndroidMainAarMetadata
+> Task :shared:vision:generateAndroidMainEmptyResourceFiles
+> Task :shared:vision:processAndroidMainManifest
+> Task :shared:core:checkAndroidMainAarMetadata
+> Task :shared:core:extractAndroidMainAnnotations
+> Task :shared:core:generateAndroidMainEmptyResourceFiles
+> Task :shared:preAndroidHostTestBuild UP-TO-DATE
+> Task :shared:core:processAndroidMainManifest
+> Task :shared:prepareLintJarForPublish
+> Task :shared:agent:prepareLintJarForPublish
+> Task :shared:core:prepareLintJarForPublish
+> Task :shared:engine:prepareLintJarForPublish
+> Task :shared:networking:prepareLintJarForPublish
+> Task :shared:simulation:prepareLintJarForPublish
+> Task :shared:subscription:prepareLintJarForPublish
+> Task :shared:tempo:prepareLintJarForPublish
+> Task :shared:vision:prepareLintJarForPublish
+> Task :shared:wled:prepareLintJarForPublish
+> Task :shared:core:processAndroidMainJavaRes
+> Task :shared:core:bundleAndroidMainClassesToCompileJar
+> Task :shared:core:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:core:mergeAndroidMainJavaResource
+> Task :shared:tempo:compileAndroidMain
+> Task :shared:tempo:bundleAndroidMainClassesToCompileJar
+> Task :shared:subscription:compileAndroidMain
+> Task :shared:subscription:bundleAndroidMainClassesToCompileJar
+> Task :shared:vision:compileAndroidMain
+> Task :shared:engine:extractAndroidMainAnnotations
+> Task :shared:vision:bundleAndroidMainClassesToCompileJar
+> Task :shared:networking:extractAndroidMainAnnotations
+> Task :shared:tempo:extractAndroidMainAnnotations
+> Task :shared:tempo:processAndroidMainJavaRes
+> Task :shared:tempo:mergeAndroidMainJavaResource
+> Task :shared:subscription:extractAndroidMainAnnotations
+> Task :shared:tempo:syncAndroidMainLibJars
+> Task :shared:tempo:bundleAndroidMainLocalLintAar
+> Task :shared:subscription:processAndroidMainJavaRes
+> Task :shared:subscription:mergeAndroidMainJavaResource
+> Task :shared:vision:extractAndroidMainAnnotations
+> Task :shared:subscription:syncAndroidMainLibJars
+> Task :shared:subscription:bundleAndroidMainLocalLintAar
+> Task :shared:vision:processAndroidMainJavaRes
+> Task :shared:vision:mergeAndroidMainJavaResource
+> Task :shared:core:syncAndroidMainLibJars
+> Task :shared:vision:syncAndroidMainLibJars
+> Task :shared:vision:bundleAndroidMainLocalLintAar
+> Task :shared:core:bundleAndroidMainLocalLintAar
+> Task :shared:core:createFullJarAndroidMain
+> Task :shared:tempo:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:subscription:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:tempo:createFullJarAndroidMain
+> Task :shared:subscription:createFullJarAndroidMain
+> Task :shared:vision:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:vision:createFullJarAndroidMain
+> Task :shared:networking:compileAndroidMain
+> Task :shared:networking:bundleAndroidMainClassesToCompileJar
+> Task :shared:networking:processAndroidMainJavaRes
+> Task :shared:simulation:extractAndroidMainAnnotations
+> Task :shared:wled:extractAndroidMainAnnotations
+> Task :shared:networking:mergeAndroidMainJavaResource
+> Task :shared:networking:syncAndroidMainLibJars
+> Task :shared:networking:bundleAndroidMainLocalLintAar
+> Task :shared:networking:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:networking:createFullJarAndroidMain
+> Task :shared:engine:compileAndroidMain
+> Task :shared:engine:bundleAndroidMainClassesToCompileJar
+> Task :shared:engine:processAndroidMainJavaRes
+> Task :shared:engine:mergeAndroidMainJavaResource
+> Task :shared:engine:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:engine:syncAndroidMainLibJars
+> Task :shared:engine:bundleAndroidMainLocalLintAar
+> Task :shared:engine:createFullJarAndroidMain
+
+> Task :shared:wled:compileAndroidMain
+w: file:///app/shared/wled/src/androidMain/kotlin/com/chromadmx/wled/WledMdnsBrowserAndroid.kt:41:24 'fun resolveService(p0: NsdServiceInfo!, p1: NsdManager.ResolveListener!): Unit' is deprecated. Deprecated in Java.
+w: file:///app/shared/wled/src/androidMain/kotlin/com/chromadmx/wled/WledMdnsBrowserAndroid.kt:64:34 'var host: InetAddress!' is deprecated. Deprecated in Java.
+
+> Task :shared:wled:processAndroidMainJavaRes
+> Task :shared:wled:bundleAndroidMainClassesToCompileJar
+
+> Task :shared:simulation:compileAndroidMain
+w: file:///app/shared/simulation/src/commonMain/kotlin/com/chromadmx/simulation/camera/SimulatedCamera.kt:155:71 Redundant call of conversion method.
+
+> Task :shared:simulation:bundleAndroidMainClassesToCompileJar
+> Task :shared:agent:extractAndroidMainAnnotations
+> Task :shared:simulation:processAndroidMainJavaRes
+> Task :shared:simulation:mergeAndroidMainJavaResource
+> Task :shared:wled:mergeAndroidMainJavaResource
+> Task :shared:simulation:syncAndroidMainLibJars
+> Task :shared:simulation:bundleAndroidMainLocalLintAar
+> Task :shared:wled:syncAndroidMainLibJars
+> Task :shared:wled:bundleAndroidMainLocalLintAar
+> Task :shared:simulation:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:wled:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:simulation:createFullJarAndroidMain
+> Task :shared:wled:createFullJarAndroidMain
+> Task :shared:agent:compileAndroidMain
+> Task :shared:agent:processAndroidMainJavaRes
+> Task :shared:agent:bundleAndroidMainClassesToCompileJar
+> Task :shared:agent:mergeAndroidMainJavaResource
+> Task :shared:agent:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:extractAndroidMainAnnotations
+> Task :shared:agent:syncAndroidMainLibJars
+> Task :shared:agent:bundleAndroidMainLocalLintAar
+> Task :shared:agent:createFullJarAndroidMain
+> Task :shared:compileAndroidMain
+> Task :shared:processAndroidMainJavaRes
+> Task :shared:mergeAndroidMainJavaResource
+> Task :shared:bundleAndroidMainClassesToRuntimeJar
+> Task :shared:syncAndroidMainLibJars
+> Task :shared:bundleAndroidMainLocalLintAar
+> Task :shared:createFullJarAndroidMain
+> Task :shared:lintAnalyzeAndroidHostTest
+
+[Incubating] Problems report is available at: file:///app/build/reports/problems/problems-report.html
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
+
+BUILD SUCCESSFUL in 7m 42s
+161 actionable tasks: 161 executed
+Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.3.1/userguide/configuration_cache_enabling.html

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            value = checked,
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->

--- a/test_out.txt
+++ b/test_out.txt
@@ -1,0 +1,224 @@
+> Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :build-logic:convention:compileKotlin UP-TO-DATE
+> Task :build-logic:convention:compileJava NO-SOURCE
+> Task :build-logic:convention:pluginDescriptors UP-TO-DATE
+> Task :build-logic:convention:processResources UP-TO-DATE
+> Task :build-logic:convention:classes UP-TO-DATE
+> Task :build-logic:convention:jar UP-TO-DATE
+
+> Configure project :shared:tempo
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosX64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosX64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosSimulatorArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosSimulatorArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ CInterop Commonization Disabled[0m[0m
+The project is using Kotlin Multiplatform with hierarchical structure and disabled 'cinterop commonization'
+
+'cinterop commonization' can be enabled in your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization=true
+
+To hide this message, add to your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization.nowarn=true
+
+The following source sets are affected:
+[appleMain, iosMain, nativeMain]
+
+The following cinterops are affected:
+[cinterop:compilation/compileKotlinIosArm64/abletonLink, cinterop:compilation/compileKotlinIosSimulatorArm64/abletonLink, cinterop:compilation/compileKotlinIosX64/abletonLink]
+[32m[1mSolution:[0m[0m
+[32m[3mPlease enable 'cinterop commonization' in your 'gradle.properties'[0m[0m
+[36mSee: [0m[34mhttps://kotlinlang.org/docs/mpp-share-on-platforms.html#use-native-libraries-in-the-hierarchical-structure[0m[36m[0m
+
+
+> Task :shared:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:convertXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
+> Task :shared:generateResourceAccessorsForAndroidMain NO-SOURCE
+> Task :shared:convertXmlValueResourcesForCommonMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForCommonMain UP-TO-DATE
+> Task :shared:prepareComposeResourcesTaskForCommonMain UP-TO-DATE
+> Task :shared:generateResourceAccessorsForCommonMain UP-TO-DATE
+> Task :shared:generateActualResourceCollectorsForAndroidMain UP-TO-DATE
+> Task :shared:generateComposeResClass UP-TO-DATE
+> Task :shared:generateExpectResourceCollectorsForCommonMain UP-TO-DATE
+> Task :shared:agent:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:core:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:core:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:core:generateCommonMainChromaDmxDatabaseInterface UP-TO-DATE
+> Task :shared:core:compileAndroidMain UP-TO-DATE
+> Task :shared:core:androidPreBuild UP-TO-DATE
+> Task :shared:core:preAndroidMainBuild UP-TO-DATE
+> Task :shared:core:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:engine:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:engine:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:tempo:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:tempo:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:tempo:compileAndroidMain UP-TO-DATE
+> Task :shared:tempo:androidPreBuild UP-TO-DATE
+> Task :shared:tempo:preAndroidMainBuild UP-TO-DATE
+> Task :shared:tempo:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:engine:compileAndroidMain UP-TO-DATE
+> Task :shared:engine:androidPreBuild UP-TO-DATE
+> Task :shared:engine:preAndroidMainBuild UP-TO-DATE
+> Task :shared:engine:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:networking:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:networking:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:networking:compileAndroidMain UP-TO-DATE
+> Task :shared:networking:androidPreBuild UP-TO-DATE
+> Task :shared:networking:preAndroidMainBuild UP-TO-DATE
+> Task :shared:networking:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:wled:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:wled:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:wled:compileAndroidMain UP-TO-DATE
+> Task :shared:wled:androidPreBuild UP-TO-DATE
+> Task :shared:wled:preAndroidMainBuild UP-TO-DATE
+> Task :shared:wled:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:agent:compileAndroidMain UP-TO-DATE
+> Task :shared:agent:androidPreBuild UP-TO-DATE
+> Task :shared:agent:preAndroidMainBuild UP-TO-DATE
+> Task :shared:agent:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:simulation:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:simulation:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:vision:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:vision:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:vision:compileAndroidMain UP-TO-DATE
+> Task :shared:vision:androidPreBuild UP-TO-DATE
+> Task :shared:vision:preAndroidMainBuild UP-TO-DATE
+> Task :shared:vision:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:simulation:compileAndroidMain UP-TO-DATE
+> Task :shared:simulation:androidPreBuild UP-TO-DATE
+> Task :shared:simulation:preAndroidMainBuild UP-TO-DATE
+> Task :shared:simulation:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:subscription:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:subscription:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:subscription:compileAndroidMain UP-TO-DATE
+> Task :shared:subscription:androidPreBuild UP-TO-DATE
+> Task :shared:subscription:preAndroidMainBuild UP-TO-DATE
+> Task :shared:subscription:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:compileAndroidMain UP-TO-DATE
+> Task :shared:androidPreBuild UP-TO-DATE
+> Task :shared:preAndroidMainBuild UP-TO-DATE
+> Task :shared:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:androidJar
+> Task :shared:convertXmlValueResourcesForAndroidHostTest NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForAndroidHostTest NO-SOURCE
+> Task :shared:prepareComposeResourcesTaskForAndroidHostTest NO-SOURCE
+> Task :shared:generateResourceAccessorsForAndroidHostTest NO-SOURCE
+> Task :shared:convertXmlValueResourcesForCommonTest NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForCommonTest NO-SOURCE
+> Task :shared:prepareComposeResourcesTaskForCommonTest NO-SOURCE
+> Task :shared:generateResourceAccessorsForCommonTest NO-SOURCE
+> Task :shared:preAndroidHostTestBuild UP-TO-DATE
+> Task :shared:processAndroidHostTestJavaRes NO-SOURCE
+> Task :shared:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:agent:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:agent:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:core:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:core:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:bundleAndroidMainClassesToCompileJar
+> Task :shared:engine:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:engine:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:networking:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:networking:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:simulation:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:simulation:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:subscription:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:subscription:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:tempo:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:tempo:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:vision:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:vision:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:wled:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:wled:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:compileAndroidHostTest
+
+> Task :shared:testAndroidHostTest
+
+MascotViewModelV2Test > sendMessageAddsUserMessageToChatHistory FAILED
+    java.lang.AssertionError at MascotViewModelV2Test.kt:72
+
+MascotViewModelV2Test > agentResponseAppearsInChatWhenNoAgent FAILED
+    java.lang.AssertionError at MascotViewModelV2Test.kt:87
+
+SettingsViewModelV2Test > toggleSimulationOffSwitchesBothRoutersToReal FAILED
+    java.lang.AssertionError at SettingsViewModelV2Test.kt:247
+
+SetupViewModelTest > advancingThroughFullFlowReachesComplete FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:372
+
+SetupViewModelTest > confirmGenreWithoutSelectionSkipsGeneration FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:884
+
+SetupViewModelTest > stepsAdvanceInOrder FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:526
+
+SetupViewModelTest > confirmGenreWithoutServiceStillAdvances FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:863
+
+SetupViewModelTest > skipStagePreviewAdvancesToComplete FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:577
+
+SetupViewModelTest > confirmGenreAdvancesStep FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:558
+
+SetupViewModelTest > advanceFromSplashGoesToNetworkDiscovery FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:504
+
+SetupViewModelTest > enterSimulationModeSetsFlag FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:306
+
+SetupViewModelTest > persistSetupCompleteSavesNodeTopology FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:446
+
+SetupViewModelTest > confirmGenreTriggersPresetGeneration FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:837
+
+SetupViewModelTest > skipToCompletePersistsSettings FAILED
+    java.lang.AssertionError at SetupViewModelTest.kt:406
+
+219 tests completed, 14 failed
+
+> Task :shared:testAndroidHostTest FAILED
+
+[Incubating] Problems report is available at: file:///app/build/reports/problems/problems-report.html
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':shared:testAndroidHostTest'.
+> There were failing tests. See the report at: file:///app/shared/build/reports/tests/testAndroidHostTest/index.html
+
+* Try:
+> Run with --scan to get full insights from a Build Scan (powered by Develocity).
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
+
+BUILD FAILED in 27s
+64 actionable tasks: 14 executed, 50 up-to-date


### PR DESCRIPTION
💡 What: Replaced `Modifier.clickable` with `Modifier.toggleable` in the `PixelSwitch` custom Compose component.
🎯 Why: `Modifier.clickable(role = Role.Switch)` tells screen readers the element is a switch, but it fails to announce its current 'On' or 'Off' state when interacted with. Using `toggleable` correctly registers both the role and the boolean value state to the Compose accessibility tree.
📸 Before/After: Visuals are exactly the same, this is purely an accessibility change. 
♿ Accessibility: Custom switch components can now be properly read and interacted with using screen readers like TalkBack.

---
*PR created automatically by Jules for task [16925185718277274632](https://jules.google.com/task/16925185718277274632) started by @srMarlins*