### PR TITLE
⚡ Bolt: [performance improvement] eliminate Triple allocation in ColorUtils.hsvToRgb

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-31 - Avoid Auto-Boxing and Object Allocation in when Blocks
+**Learning:** Using `Triple` or `Pair` in exhaustive `when` expressions within hot paths (like `ColorUtils.hsvToRgb`) causes both intermediate object allocation (the `Triple` itself) and primitive auto-boxing (e.g., `Float` to `java.lang.Float`), creating significant GC pressure.
+**Action:** Refactor these structures to use deferred assignment of primitive `val` variables (e.g., `val r1: Float; when { ... -> { r1 = c } }`) to keep operations on the stack and entirely allocation-free.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,16 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Refactored the `when` expression in `ColorUtils.hsvToRgb` to replace `Triple` object return types with deferred assignment to local primitive variables (`r1`, `g1`, `b1`).
🎯 **Why:** In the DMX engine's rendering hot path, evaluating `when` blocks that return `Triple<Float, Float, Float>` causes intermediate object allocation (the `Triple` itself) and primitive auto-boxing (converting stack `Float` values to heap `java.lang.Float` objects). This leads to excessive Garbage Collection (GC) pauses and dropped frames. Using deferred assignment completely avoids these allocations.
📊 **Impact:** Reduces object allocations by 4 objects (1 Triple + 3 boxed Floats) per color conversion call, significantly lowering GC pressure during continuous rendering loops.
🔬 **Measurement:** Verify with `./gradlew :shared:engine:testAndroidHostTest` to ensure mathematical identicality, and use memory profiling to observe the reduction in `Triple` instantiations during engine evaluation.

---
*PR created automatically by Jules for task [10704548240463144661](https://jules.google.com/task/10704548240463144661) started by @srMarlins*