### PR TITLE
🎨 Palette: Make PixelSwitch state accessible via toggleable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessible Switch States
+**Learning:** Using `Modifier.clickable` on a custom switch with `Role.Switch` identifies it as a switch, but fails to announce its current 'On' or 'Off' state to screen readers.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switch/checkbox components to ensure both the role and the boolean value state are semantically exposed.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**:
Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(value = checked, role = Role.Switch)` in the custom `PixelSwitch` component.

🎯 **Why**:
While `Modifier.clickable` with `Role.Switch` identifies the element as a switch to screen readers, it fails to announce its current Boolean state (On/Off). `Modifier.toggleable` explicitly manages both the role and the value, ensuring that assistive technologies correctly announce when the switch is toggled.

♿ **Accessibility**:
This directly fixes an issue where visually impaired users wouldn't know if the switch was currently active or inactive.

📸 **Before/After**:
Visually identical. Semantically fixed.

---
*PR created automatically by Jules for task [14269904204617178494](https://jules.google.com/task/14269904204617178494) started by @srMarlins*