### PR TITLE
⚡ Bolt: Optimize BlobDetector floodFill to avoid auto-boxing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Avoid Primitive Auto-Boxing in Vision Hot Paths
+**Learning:** In performance-critical hot paths like `BlobDetector.floodFill`, using generic collections like `ArrayDeque<Int>` causes primitive auto-boxing (`Int` to `java.lang.Integer`) and frequent intermediate object allocations, which creates GC pressure.
+**Action:** Prefer pre-allocated primitive arrays (e.g., `IntArray`) to act as stacks or queues in inner loops to prevent boxing and minimize GC overhead.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -45,6 +45,9 @@ class BlobDetector(
         val labels = IntArray(w * h)
         var nextLabel = 1
 
+        // Stack pre-allocated for flood-fill to avoid auto-boxing from ArrayDeque<Int>
+        val stack = IntArray(w * h)
+
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
@@ -55,7 +58,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -63,16 +66,15 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) DetectedBlob(
                     centroid = Coord2D(
                         x = acc.weightedSumX / acc.totalBrightness,
                         y = acc.weightedSumY / acc.totalBrightness
                     ),
                     pixelCount = acc.count,
                     totalBrightness = acc.totalBrightness
-                )
+                ) else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +91,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +115,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 What: 
- Replaced `ArrayDeque<Int>` with a pre-allocated `IntArray` stack (`w * h` size) in `BlobDetector.floodFill`.
- Replaced chained `.filter` and `.map` on component values with a single `.mapNotNull`.

🎯 Why: 
In the performance-critical vision hot path (`floodFill`), using a generic collection like `ArrayDeque<Int>` causes primitive auto-boxing (from `Int` to `java.lang.Integer`) every time a pixel index is pushed or popped. This creates thousands of small objects per frame, leading to GC pressure and potential frame drops. Similarly, chained `.filter` and `.map` on collections create intermediate lists.

📊 Impact: 
Significantly reduces GC allocations during vision blob detection by keeping all flood-fill stack operations as pure primitives on a pre-allocated array. Eliminates intermediate list allocations in the component extraction phase.

🔬 Measurement: 
- Unit tests (`:shared:vision:testAndroidHostTest`) pass, confirming identical blob detection results.
- Code lint checks (`:shared:vision:lint`) pass.

---
*PR created automatically by Jules for task [4641076134564654518](https://jules.google.com/task/4641076134564654518) started by @srMarlins*