### PR TITLE
⚡ Bolt: Optimize BlobDetector hot path by replacing ArrayDeque with IntArray

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Primitive Arrays over ArrayDeque in Hot Paths
+**Learning:** In performance-critical hot paths like `BlobDetector.floodFill`, using generic collections like `ArrayDeque<Int>` for primitive types causes auto-boxing (e.g., `Int` to `java.lang.Integer`) and intermediate object creations, leading to increased GC pressure.
+**Action:** Prefer pre-allocated primitive arrays (e.g., `IntArray`) with a manual size counter to implement stacks or queues in hot paths, avoiding object allocations entirely.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -44,6 +44,7 @@ class BlobDetector(
         // Label array: 0 = unlabeled, >0 = component label
         val labels = IntArray(w * h)
         var nextLabel = 1
+        val stack = IntArray(w * h)
 
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
@@ -55,7 +56,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -63,16 +64,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +91,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +115,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 **What:** Optimized the `BlobDetector` hot path by replacing `ArrayDeque<Int>` with a pre-allocated primitive `IntArray` stack, and combined a `.filter` and `.map` chain into a single `.mapNotNull` pass.
🎯 **Why:** The generic `ArrayDeque<Int>` causes primitive auto-boxing (`Int` to `java.lang.Integer`) resulting in unnecessary object allocations per pixel processed during flood-fill, increasing GC pressure and latency. The collection refactor avoids an intermediate list creation.
📊 **Impact:** Significantly reduces object allocations in the critical computer vision loop, leading to fewer GC pauses and lower latency during real-time blob detection.
🔬 **Measurement:** Code compiles, passes lint, and the vision module's unit tests (`BlobDetectorTest.kt`) continue to pass. The allocation reduction can be verified via a CPU/Memory profiler during active vision frames.

---
*PR created automatically by Jules for task [4351116757003279972](https://jules.google.com/task/4351116757003279972) started by @srMarlins*