### PR TITLE
⚡ Bolt: Remove Triple allocation in ColorUtils.hsvToRgb

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-02-28 - Removed Triple allocation in ColorUtils
+**Learning:** Using `Triple` or `Pair` with primitives in Kotlin hot loops (like color conversion) causes hidden object allocations and primitive auto-boxing (e.g. `Float` to `java.lang.Float`), creating GC pressure.
+**Action:** Use deferred initialization of primitive local variables instead of `Triple` in `when` expressions inside performance-critical paths.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,16 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f  -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else       -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
💡 **What:** Replaced the `Triple` allocation in the exhaustive `when` block of `ColorUtils.hsvToRgb` with deferred initialization of primitive local variables (`r1`, `g1`, `b1`).
🎯 **Why:** `hsvToRgb` is a hot-path utility used heavily in DMX rendering. The previous implementation allocated a new `Triple` object for every color conversion and implicitly auto-boxed primitive `Float` values into `java.lang.Float` objects, creating unnecessary garbage collection (GC) pressure and potential framerate stutter.
📊 **Impact:** Completely eliminates object allocations and auto-boxing in `hsvToRgb`, improving performance and reducing GC pauses without changing behavior or readability.
🔬 **Measurement:** Compile and test via `./gradlew :shared:engine:testAndroidHostTest` to verify that `hsvToRgb` correctly converts standard hues to expected RGB bounds.

---
*PR created automatically by Jules for task [437285245585034437](https://jules.google.com/task/437285245585034437) started by @srMarlins*