### PR TITLE
⚡ Bolt: Optimize `ColorUtils.hsvToRgb` to reduce GC pressure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2024-05-18 - Avoid Triple allocations in hot path when blocks
+**Learning:** Using `val (a, b) = when { ... -> Triple(x,y,z) }` in Kotlin performance-critical hot paths (like DMX engine inner loops or color conversions) causes primitive auto-boxing and intermediate object creations (`Triple`), leading to GC pressure.
+**Action:** Use deferred assignment of primitive `val` variables (e.g., `val r1: Float; when { ... -> { r1 = c } }`) to prevent GC pauses and frame drops.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/util/ColorUtils.kt
@@ -22,13 +22,16 @@ object ColorUtils {
         val x = c * (1f - abs((hue / 60f) % 2f - 1f))
         val m = v - c
 
-        val (r1, g1, b1) = when {
-            hue < 60f  -> Triple(c, x, 0f)
-            hue < 120f -> Triple(x, c, 0f)
-            hue < 180f -> Triple(0f, c, x)
-            hue < 240f -> Triple(0f, x, c)
-            hue < 300f -> Triple(x, 0f, c)
-            else       -> Triple(c, 0f, x)
+        val r1: Float
+        val g1: Float
+        val b1: Float
+        when {
+            hue < 60f -> { r1 = c; g1 = x; b1 = 0f }
+            hue < 120f -> { r1 = x; g1 = c; b1 = 0f }
+            hue < 180f -> { r1 = 0f; g1 = c; b1 = x }
+            hue < 240f -> { r1 = 0f; g1 = x; b1 = c }
+            hue < 300f -> { r1 = x; g1 = 0f; b1 = c }
+            else -> { r1 = c; g1 = 0f; b1 = x }
         }
 
         return Color(r1 + m, g1 + m, b1 + m)


### PR DESCRIPTION
### 💡 What
Replaced the `Triple` allocation and destructuring in `ColorUtils.hsvToRgb` with deferred primitive assignments (`val r1: Float`, `val g1: Float`, `val b1: Float`).

### 🎯 Why
`ColorUtils.hsvToRgb` is often called thousands of times per frame in the DMX rendering loop (e.g., when evaluating color palettes or effects). In Kotlin, returning a `Triple(x, y, z)` where the elements are primitives (`Float`) causes two issues:
1. It allocates a new `Triple` object on the heap.
2. It auto-boxes the primitive `Float` values into `java.lang.Float` objects.

Doing this for every color conversion creates immense Garbage Collection (GC) pressure, which can cause micro-stutters or frame drops in the effect engine.

### 📊 Impact
* **Reduces Object Allocations**: Eliminates 1 `Triple` and 3 `Float` box allocations per `hsvToRgb` call.
* **Reduces GC Pressure**: Less garbage generated in the rendering loop, leading to more stable frame rates.
* **Preserves Readability**: The refactored `when` block is still clean and easy to follow.

### 🔬 Measurement
Run `./gradlew :shared:engine:testAndroidHostTest` to verify that all color conversion logic remains perfectly intact. A profiler tracking object allocations during the engine's `tick()` loop will show a reduction in `Triple` and `java.lang.Float` instances.

---
*PR created automatically by Jules for task [15466714361579196734](https://jules.google.com/task/15466714361579196734) started by @srMarlins*