### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-01-23 - PixelSwitch Accessibility State Announcement
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` on custom switch components identifies the element as a switch but fails to announce its current 'On' or 'Off' state to screen readers.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switches in Compose Multiplatform to properly set semantics for both the role and the value state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**: Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(value = checked, role = Role.Switch)` in `PixelSwitch.kt`. Added the necessary import.
🎯 **Why**: Using `clickable` on a custom switch component identifies it as a switch but fails to announce its state to screen readers. `toggleable` natively supports both the role and state announcements, fixing the accessibility issue.
📸 **Before/After**: N/A - strictly an accessibility semantics update; visual appearance remains identical.
♿ **Accessibility**: Improved screen reader experience by properly announcing the 'On' or 'Off' state of the switch. Recorded critical learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [13496812633345801103](https://jules.google.com/task/13496812633345801103) started by @srMarlins*