### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility with toggleable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-09 - PixelSwitch Accessibility
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` for custom switches identifies the component as a switch to screen readers but fails to announce its current "On" or "Off" state.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switch/checkbox components in Compose Multiplatform to properly bind the semantic value state to the accessibility tree.

--- a/PLANNED_UX_IMPROVEMENTS.md
+++ b/PLANNED_UX_IMPROVEMENTS.md
@@ -5,7 +5,7 @@
 - **Typography Update**: Ensure `PixelFontFamily` is used consistently for headers, while a legible monospace or sans-serif font is used for data/body text.
 - **Component Library**:
     - [ ] Create `PixelScaffold`: A standard layout container with a pixelated top bar and bottom navigation.
-    - [ ] Create `PixelSwitch`: A toggle switch with pixel-art "on/off" states.
+    - [x] Create `PixelSwitch`: A toggle switch with pixel-art "on/off" states.
     - [ ] Create `PixelTextField`: An input field with pixel borders and clear focus states.
     - [ ] Refactor `PixelSlider`: Improve touch targets, add accessibility semantics, and smooth out the thumb dragging.
     - [ ] Refactor `PixelButton`: Add disabled states, loading indicators, and haptic feedback.

--- a/fix_switch.py
+++ b/fix_switch.py
@@ -1,0 +1,35 @@
+import os
+
+filepath = "shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt"
+with open(filepath, "r") as f:
+    content = f.read()
+
+# Add import
+import_clickable = "import androidx.compose.foundation.clickable"
+import_toggleable = "import androidx.compose.foundation.selection.toggleable"
+
+if import_toggleable not in content:
+    content = content.replace(import_clickable, import_clickable + "\nimport androidx.compose.foundation.selection.toggleable")
+
+# Replace clickable
+old_code = """        .clickable(
+            interactionSource = interactionSource,
+            indication = null,
+            enabled = enabled,
+            onClick = { onCheckedChange?.invoke(!checked) },
+            role = Role.Switch
+        )"""
+
+new_code = """        .toggleable(
+            value = checked,
+            interactionSource = interactionSource,
+            indication = null,
+            enabled = enabled,
+            onValueChange = { onCheckedChange?.invoke(it) },
+            role = Role.Switch
+        )"""
+
+content = content.replace(old_code, new_code)
+
+with open(filepath, "w") as f:
+    f.write(content)

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +55,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->

--- a/test_switch.patch
+++ b/test_switch.patch
@@ -1,0 +1,25 @@
+--- shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
++++ shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+@@ -10,7 +10,7 @@
+ import androidx.compose.runtime.Composable
+ import androidx.compose.runtime.getValue
+ import androidx.compose.runtime.remember
++import androidx.compose.foundation.selection.toggleable
+ import androidx.compose.ui.Alignment
+ import androidx.compose.ui.Modifier
+ import androidx.compose.ui.draw.clip
+@@ -53,10 +53,11 @@
+     // Track uses chamfered shape; glowing when checked, standard when unchecked
+     val trackModifier = modifier
+         .size(width = trackWidth, height = trackHeight)
+-        .clickable(
++        .toggleable(
++            value = checked,
+             interactionSource = interactionSource,
+             indication = null,
+             enabled = enabled,
+-            onClick = { onCheckedChange?.invoke(!checked) },
++            onValueChange = { onCheckedChange?.invoke(it) },
+             role = Role.Switch
+         )
+         .let { mod ->


### PR DESCRIPTION
🎨 Palette: Improve PixelSwitch accessibility with toggleable

Refactored `PixelSwitch` to use Compose's `Modifier.toggleable` instead of `Modifier.clickable`.

💡 What: Replaced `Modifier.clickable` with `Modifier.toggleable` on the `PixelSwitch` track modifier.
🎯 Why: `clickable(role = Role.Switch)` identifies the component as a switch but fails to announce its current "On" or "Off" value state to screen readers. `toggleable` correctly binds the boolean value state to the semantic tree.
📸 Before/After: Visuals remain unchanged, but accessibility tree now correctly reflects state.
♿ Accessibility: Screen readers will now correctly announce "Switch, On" or "Switch, Off" when interacting with the component.

---
*PR created automatically by Jules for task [9274444157328326091](https://jules.google.com/task/9274444157328326091) started by @srMarlins*