### PR TITLE
⚡ Bolt: Optimize BlobDetector allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Avoid Auto-Boxing and Chained Collections in Hot Paths
+**Learning:** In performance-critical hot paths like `BlobDetector.floodFill`, using generic collections like `ArrayDeque<Int>` for primitive types causes auto-boxing (`Int` to `java.lang.Integer`) and frequent object allocations. Similarly, chaining `.filter { ... }.map { ... }` creates intermediate collections.
+**Action:** Use pre-allocated primitive arrays (e.g., `IntArray`) to avoid auto-boxing and minimize GC pressure. Use `.mapNotNull { if (condition) result else null }` to combine filtering and mapping into a single traversal without intermediate allocations.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,9 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        // Pre-allocate a single stack for floodFill to avoid allocations
+        val floodStack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,7 +58,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, floodStack)
                     components[label] = acc
                 }
             }
@@ -63,16 +66,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +93,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        floodStack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackPtr = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        floodStack[stackPtr++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackPtr > 0) {
+            val idx = floodStack[--stackPtr]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +117,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    floodStack[stackPtr++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    floodStack[stackPtr++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    floodStack[stackPtr++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    floodStack[stackPtr++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 **What**: The optimization implemented
Replaced the `ArrayDeque<Int>` in `BlobDetector.floodFill` with a pre-allocated `IntArray` that acts as a custom stack. Also merged `.filter {}.map {}` in `detect` into a single `.mapNotNull {}`.

🎯 **Why**: The performance problem it solves
The generic collection `ArrayDeque<Int>` leads to primitive auto-boxing (`Int` to `java.lang.Integer`) on the JVM. In a highly-iterative operation like `floodFill`, this creates immense GC pressure from creating and destroying integer objects for every pixel pushed to the stack. Furthermore, chained sequence collections like `.filter().map()` incur hidden array allocations for intermediate results.

📊 **Impact**: Expected performance improvement
Eliminates hundreds of thousands of auto-boxed integer object allocations per detected blob by utilizing raw primitives, significantly reducing CPU cycles and the risk of GC frame stutter. Eliminates an intermediate array list allocation per detection cycle. 

🔬 **Measurement**: How to verify the improvement
Can be verified by tracing object allocations via Android Studio Profiler during camera tracking; expect to see `java.lang.Integer` creation rates near 0 from `BlobDetector` compared to thousands prior. Run `./gradlew :shared:vision:testAndroidHostTest` to ensure connected-component labeling and centroid functionality operates flawlessly under the refactor.

---
*PR created automatically by Jules for task [7283156598938481515](https://jules.google.com/task/7283156598938481515) started by @srMarlins*