### PR TITLE
🎨 Palette: [UX improvement] Fix PixelSwitch accessibility state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-08 - Use toggleable instead of clickable for custom switches
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` identifies a custom switch component as a switch, but it doesn't announce its current "On" or "Off" state to screen readers.
+**Action:** Use `Modifier.toggleable(value = checked, ...)` instead of `clickable` to ensure the component's state is properly announced.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 **What**: Updated `PixelSwitch` to use Compose's `Modifier.toggleable` instead of `Modifier.clickable(role = Role.Switch)`.
🎯 **Why**: Using `clickable` correctly identifies the component as a switch, but it doesn't hook into the state tracking required to announce whether the switch is currently "On" or "Off". Screen reader users need this feedback to know the component's state.
📸 **Before/After**: Visually identical, purely an accessibility semantics fix.
♿ **Accessibility**: Screen readers will now announce "On" or "Off" when the custom `PixelSwitch` component is focused or interacted with.

---
*PR created automatically by Jules for task [15181665218654061561](https://jules.google.com/task/15181665218654061561) started by @srMarlins*