### PR TITLE
🛡️ Sentinel: [HIGH] Fix OS dictionary caching of sensitive data fields

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+
+## 2025-02-28 - Prevent OS caching of passwords
+**Vulnerability:** OS keyboards dictionary cache and autocomplete features could capture sensitive data (API Keys, Passwords) because they were entered in standard text fields.
+**Learning:** Even if visually masked using `PasswordVisualTransformation`, text fields must explicitly specify `KeyboardType.Password` and `autoCorrectEnabled = false` to communicate to the OS keyboard that the input is sensitive.
+**Prevention:** Always combine `PasswordVisualTransformation` with `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` on Compose text fields handling secrets.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -1,5 +1,7 @@
 package com.chromadmx.ui.screen.settings
 
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -442,7 +444,8 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
-                        singleLine = true
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)
                     )
 
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -744,6 +744,7 @@ private fun AgentSection(
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
                 modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
             )
 
             // Model selector


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: OS keyboards (iOS/Android) dictionary cache and autocomplete features could capture and store sensitive data (API Keys, Wi-Fi Passwords) because they were entered in standard text fields, despite being visually masked.
🎯 Impact: Sensitive user secrets could be cached in plain text by the OS keyboard, potentially exposing them via keyboard suggestions or OS-level dictionary syncing.
🔧 Fix: Explicitly added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the `PixelTextField` for API Keys and `OutlinedTextField` for Wi-Fi Passwords to signal to the OS that the input is a secret and should not be cached.
✅ Verification: Successfully compiled the project, ran lint, executed host tests, and completed frontend UI verification instructions.

---
*PR created automatically by Jules for task [6473224779590972705](https://jules.google.com/task/6473224779590972705) started by @srMarlins*