### PR TITLE
🎨 Palette: [UX improvement] Enhance PixelSwitch accessibility with toggleable modifier

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Compose Multiplatform Switch Accessibility
+**Learning:** Custom switch components using `Modifier.clickable(role = Role.Switch)` do not announce their "On"/"Off" value to screen readers.
+**Action:** Always use `Modifier.toggleable(value = checked, role = Role.Switch)` for custom switches so that both the semantic role and the current state value are correctly announced.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
💡 What: Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable(value = checked, role = Role.Switch)` in `PixelSwitch.kt`.
🎯 Why: Custom switch components using `clickable` do not correctly announce their "On" or "Off" value state to screen readers.
📸 Before/After: N/A (Visuals remain identical; purely a semantic enhancement).
♿ Accessibility: Ensures that screen readers can accurately report the toggle state of the switch to users.

---
*PR created automatically by Jules for task [6204541882545401311](https://jules.google.com/task/6204541882545401311) started by @srMarlins*