### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Improve PixelSwitch Accessibility
+**Learning:** `Modifier.clickable(role = Role.Switch)` properly identifies a component as a switch, but it fails to communicate the current 'On'/'Off' state to screen readers. `Modifier.toggleable` properly provides semantics for both the role and the value state.
+**Action:** Use `Modifier.toggleable(value = checked, ...)` instead of `Modifier.clickable` for custom switch components.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,11 +54,12 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
+        .toggleable(
+            value = checked,
             interactionSource = interactionSource,
             indication = null,
             enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
+            onValueChange = { onCheckedChange?.invoke(it) },
             role = Role.Switch
         )
         .let { mod ->


### PR DESCRIPTION
🎨 Palette: Improve PixelSwitch accessibility

💡 What: Updated the `PixelSwitch` component to use Compose Multiplatform's `Modifier.toggleable` instead of `Modifier.clickable` with `Role.Switch`.
🎯 Why: `Modifier.clickable` correctly identifies the component as a switch to screen readers but fails to communicate its current "On" or "Off" value state, leading to a confusing accessibility experience.
♿ Accessibility: `Modifier.toggleable` provides the correct semantics for both the switch role and its underlying boolean state.

---
*PR created automatically by Jules for task [10286733539932889438](https://jules.google.com/task/10286733539932889438) started by @srMarlins*