### PR TITLE
⚡ Bolt: Optimize BlobDetector primitive allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2024-05-24 - BlobDetector flood-fill array allocations
+**Learning:** Using generic collections like `ArrayDeque<Int>` for primitives in hot paths causes auto-boxing and GC pressure. Chained `.filter().map()` causes intermediate allocations.
+**Action:** Use pre-allocated primitive arrays like `IntArray` and manage the index manually. Use `.mapNotNull()` to combine filtering and mapping.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,8 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        val stack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,7 +57,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -63,16 +65,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +92,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +116,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 **What:** Replaced the generic `ArrayDeque<Int>` stack with an explicit `IntArray` in `BlobDetector.floodFill` and collapsed the `.filter { }.map { }` chain in `detect()` to `.mapNotNull { }`.
🎯 **Why:** `ArrayDeque<Int>` causes auto-boxing of `Int` to `java.lang.Integer`, which triggers massive garbage collection (GC) pressure inside the hot loops of computer vision flood-filling (potentially tens of thousands of object allocations per frame). By using an explicitly sized primitive `IntArray` managed with an index, we allocate exactly one object per frame detection cycle. Additionally, the `.filter` combined with `.map` generated an intermediate collection per frame which is now avoided.
📊 **Impact:** Reduces GC pauses significantly. Eliminates all primitive auto-boxing in the flood-fill inner loop and removes $O(N)$ intermediate object collections from blob filtering.
🔬 **Measurement:** Compile, Lint, and `BlobDetector` unit tests all verified to maintain logic stability. Run `./gradlew :shared:vision:testAndroidHostTest` to verify.

---
*PR created automatically by Jules for task [18058552832860149795](https://jules.google.com/task/18058552832860149795) started by @srMarlins*