### PR TITLE
🎨 Palette: [UX improvement] Fix PixelSwitch screen reader semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Compose Multiplatform Custom Switch Accessibility
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` for custom switches incorrectly identifies the element as a switch but does not announce its current 'On' or 'Off' state to screen readers.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switch components to properly set the semantics for both the role and the value state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,13 +55,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                mod
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What**: Replaced `Modifier.clickable` with `Modifier.toggleable` in the `PixelSwitch` component.
🎯 **Why**: When using `clickable` with `role = Role.Switch`, screen readers correctly announce the element as a switch, but fail to announce its current checked value (On/Off). `toggleable` natively supports both the role and state value, providing the necessary semantics for accessibility tools.
📸 **Before/After**: Visually identical, purely a semantic change for screen readers.
♿ **Accessibility**: Improves screen reader compatibility by accurately announcing the current state of custom toggle switches.

---
*PR created automatically by Jules for task [6488209292857209455](https://jules.google.com/task/6488209292857209455) started by @srMarlins*