### PR TITLE
⚡ Bolt: [performance improvement] Optimize BlobDetector allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2025-04-12 - BlobDetector Hot Path Optimizations
+**Learning:** In `BlobDetector.kt` (used on vision frames), there was a performance bottleneck caused by chained collections operations (`.filter { ... }.map { ... }`) creating intermediate collections, and the use of generic collections like `ArrayDeque<Int>` for primitive types which causes auto-boxing and memory allocations per iteration.
+**Action:** When working with image processing hot loops in vision layers, avoid primitive auto-boxing by substituting collections with pre-allocated primitive arrays (like `IntArray`). Replace chained `filter`/`map` calls with `.mapNotNull { ... }` to achieve single-pass processing without intermediate collection allocations.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -45,6 +45,9 @@ class BlobDetector(
         val labels = IntArray(w * h)
         var nextLabel = 1
 
+        // Pre-allocated stack for flood-fill to avoid primitive auto-boxing
+        val stack = IntArray(w * h)
+
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
@@ -55,7 +58,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -63,16 +66,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +93,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +117,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 What: Optimized `BlobDetector.kt` by replacing `ArrayDeque<Int>` with a pre-allocated `IntArray` stack for flood-fill, and condensing `.filter { ... }.map { ... }` to a single `.mapNotNull { ... }`.
🎯 Why: `BlobDetector` runs on vision frames as a hot path. The previous generic queue triggered primitive auto-boxing and intermediate object allocations per pixel/frame, leading to excessive GC pauses and dropped frames. Chained collections compounded this by allocating intermediate lists.
📊 Impact: Eliminates thousands of object allocations per frame by preventing primitive auto-boxing and skipping intermediate collection creation, yielding significant GC pressure relief.
🔬 Measurement: Verify stable frame processing and absence of stutter in blob detection tasks on-device. Build stability and correctness are verified via `:shared:vision:testAndroidHostTest`.

---
*PR created automatically by Jules for task [11558531853973013955](https://jules.google.com/task/11558531853973013955) started by @srMarlins*