### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Compose Accessibility for Switch Components
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` correctly identifies the element as a switch but fails to announce its current 'On' or 'Off' state. `Modifier.toggleable` correctly communicates both the role and its current state.
+**Action:** Always use `toggleable` instead of `clickable` for custom switch or checkbox components in Compose Multiplatform to ensure screen readers announce their state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -54,13 +54,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { baseMod ->
+            if (onCheckedChange != null) {
+                baseMod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                baseMod
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What:** Replaced `Modifier.clickable` with `Modifier.toggleable` in the `PixelSwitch` component. Since the `onCheckedChange` callback is nullable, the `toggleable` modifier is conditionally applied using a `.let` block.
🎯 **Why:** To improve accessibility. The previous implementation used `clickable(role = Role.Switch)`, which identified the element to screen readers but did not announce its state.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now correctly announce both the role ("Switch") and the current value ("On" or "Off") of the component.

---
*PR created automatically by Jules for task [12695010806842174102](https://jules.google.com/task/12695010806842174102) started by @srMarlins*