### PR TITLE
⚡ Bolt: [performance improvement] Eliminate auto-boxing in BlobDetector floodFill

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-02 - Pre-allocate Primitive Array Stacks to Avoid Auto-boxing
+**Learning:** In hot path algorithms like `BlobDetector.floodFill`, using generic collections like `ArrayDeque<Int>` causes primitive auto-boxing and significant object allocations per component.
+**Action:** Replace `ArrayDeque<Int>` with a pre-allocated primitive array (`IntArray`) passed directly from the caller to manage stack states, eliminating allocations entirely.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,9 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        // Pre-allocate primitive array stack to avoid auto-boxing in floodFill
+        val stack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,7 +58,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -89,15 +92,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +116,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 What: Replaced the `ArrayDeque<Int>` in `BlobDetector.floodFill` with a pre-allocated primitive `IntArray` stack.
🎯 Why: `ArrayDeque<Int>` is a generic collection that causes primitive `Int` values to be auto-boxed into `java.lang.Integer` objects upon insertion. In a hot path like single-pass flood fill component detection running at 60fps, this generated massive object allocations per pixel, causing severe GC pressure and frame drops. 
📊 Impact: Eliminates object allocations inside the `floodFill` inner loop entirely. Stack operations are now zero-allocation index increments/decrements on a flat array, making component detection significantly faster and more stable under heavy load.
🔬 Measurement: Verify stable frame pacing by running the engine with active vision inputs and monitoring GC pauses. The unit test suite `testAndroidHostTest` has been run to ensure identical CCL detection logic.

---
*PR created automatically by Jules for task [2906707011127683577](https://jules.google.com/task/2906707011127683577) started by @srMarlins*