### PR TITLE
🎨 Palette: [UX improvement] Add ARIA-equivalent contentDescription to icon-only PixelIconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - ARIA equivalent semantics for custom Compose components
+**Learning:** Custom Compose components (like `PixelIconButton` built on top of `Box` + `clickable`) don't automatically expose or apply `contentDescription` for screen readers, unlike standard Material components.
+**Action:** Always verify that custom icon-only components expose a `contentDescription` parameter and map it to `Modifier.semantics { this.contentDescription = ... }`.

--- a/lint_output.txt
+++ b/lint_output.txt
@@ -1,0 +1,257 @@
+> Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :build-logic:convention:compileKotlin UP-TO-DATE
+> Task :build-logic:convention:compileJava NO-SOURCE
+> Task :build-logic:convention:pluginDescriptors UP-TO-DATE
+> Task :build-logic:convention:processResources UP-TO-DATE
+> Task :build-logic:convention:classes UP-TO-DATE
+> Task :build-logic:convention:jar UP-TO-DATE
+
+> Configure project :shared:tempo
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosX64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosX64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ Cross Compilation with Cinterop Not Supported in Project 'tempo'[0m[0m
+In project 'tempo', cross compilation to target 'iosSimulatorArm64' has been disabled because it contains cinterops: 'abletonLink' which cannot be processed on host 'linux_x64'.
+Cinterop libraries require platform-specific native toolchains that aren't available on the current host system.
+[32m[1mSolutions:[0m[0m
+[32m • [3mRemove the cinterop dependencies 'abletonLink' from target 'iosSimulatorArm64'[0m[0m
+[32m • [3mBuild on a compatible host platform for this target/cinterop combination[0m[0m
+[32m • [3mTo disable klib cross compilation entirely, add 'kotlin.native.enableKlibsCrossCompilation=false' to your Gradle properties[0m[0m
+
+w: [33m[1m⚠️ CInterop Commonization Disabled[0m[0m
+The project is using Kotlin Multiplatform with hierarchical structure and disabled 'cinterop commonization'
+
+'cinterop commonization' can be enabled in your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization=true
+
+To hide this message, add to your 'gradle.properties'
+kotlin.mpp.enableCInteropCommonization.nowarn=true
+
+The following source sets are affected:
+[appleMain, iosMain, nativeMain]
+
+The following cinterops are affected:
+[cinterop:compilation/compileKotlinIosArm64/abletonLink, cinterop:compilation/compileKotlinIosSimulatorArm64/abletonLink, cinterop:compilation/compileKotlinIosX64/abletonLink]
+[32m[1mSolution:[0m[0m
+[32m[3mPlease enable 'cinterop commonization' in your 'gradle.properties'[0m[0m
+[36mSee: [0m[34mhttps://kotlinlang.org/docs/mpp-share-on-platforms.html#use-native-libraries-in-the-hierarchical-structure[0m[36m[0m
+
+
+> Task :shared:convertXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
+> Task :shared:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
+> Task :shared:generateResourceAccessorsForAndroidMain NO-SOURCE
+> Task :shared:convertXmlValueResourcesForCommonMain NO-SOURCE
+> Task :shared:copyNonXmlValueResourcesForCommonMain UP-TO-DATE
+> Task :shared:prepareComposeResourcesTaskForCommonMain UP-TO-DATE
+> Task :shared:generateResourceAccessorsForCommonMain UP-TO-DATE
+> Task :shared:androidPreBuild UP-TO-DATE
+> Task :shared:preAndroidMainBuild UP-TO-DATE
+> Task :shared:agent:androidPreBuild UP-TO-DATE
+> Task :shared:agent:preAndroidMainBuild UP-TO-DATE
+> Task :shared:agent:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:core:androidPreBuild UP-TO-DATE
+> Task :shared:core:preAndroidMainBuild UP-TO-DATE
+> Task :shared:core:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:engine:androidPreBuild UP-TO-DATE
+> Task :shared:engine:preAndroidMainBuild UP-TO-DATE
+> Task :shared:engine:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:networking:androidPreBuild UP-TO-DATE
+> Task :shared:networking:preAndroidMainBuild UP-TO-DATE
+> Task :shared:networking:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:simulation:androidPreBuild UP-TO-DATE
+> Task :shared:simulation:preAndroidMainBuild UP-TO-DATE
+> Task :shared:simulation:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:subscription:androidPreBuild UP-TO-DATE
+> Task :shared:subscription:preAndroidMainBuild UP-TO-DATE
+> Task :shared:subscription:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:tempo:androidPreBuild UP-TO-DATE
+> Task :shared:tempo:preAndroidMainBuild UP-TO-DATE
+> Task :shared:tempo:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:vision:androidPreBuild UP-TO-DATE
+> Task :shared:vision:preAndroidMainBuild UP-TO-DATE
+> Task :shared:vision:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:wled:androidPreBuild UP-TO-DATE
+> Task :shared:wled:preAndroidMainBuild UP-TO-DATE
+> Task :shared:wled:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:agent:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:core:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:core:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:core:generateCommonMainChromaDmxDatabaseInterface UP-TO-DATE
+> Task :shared:core:compileAndroidMain UP-TO-DATE
+> Task :shared:core:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:engine:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:engine:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:tempo:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:tempo:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:tempo:compileAndroidMain UP-TO-DATE
+> Task :shared:tempo:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:engine:compileAndroidMain UP-TO-DATE
+> Task :shared:engine:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:networking:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:networking:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:networking:compileAndroidMain UP-TO-DATE
+> Task :shared:networking:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:wled:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:wled:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:wled:compileAndroidMain UP-TO-DATE
+> Task :shared:wled:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:agent:compileAndroidMain UP-TO-DATE
+> Task :shared:agent:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:simulation:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:simulation:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:vision:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:vision:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:vision:compileAndroidMain UP-TO-DATE
+> Task :shared:vision:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:simulation:compileAndroidMain UP-TO-DATE
+> Task :shared:simulation:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:subscription:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:subscription:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:subscription:compileAndroidMain UP-TO-DATE
+> Task :shared:subscription:bundleAndroidMainClassesToCompileJar UP-TO-DATE
+> Task :shared:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:processAndroidMainManifest UP-TO-DATE
+> Task :shared:kmpPartiallyResolvedDependenciesChecker
+> Task :shared:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :shared:generateActualResourceCollectorsForAndroidMain UP-TO-DATE
+> Task :shared:generateComposeResClass UP-TO-DATE
+> Task :shared:generateExpectResourceCollectorsForCommonMain UP-TO-DATE
+> Task :shared:compileAndroidMain UP-TO-DATE
+> Task :shared:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:writeAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:agent:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:agent:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:agent:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:agent:processAndroidMainManifest UP-TO-DATE
+> Task :shared:agent:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:agent:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:agent:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:agent:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:engine:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:engine:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:engine:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:engine:processAndroidMainManifest UP-TO-DATE
+> Task :shared:engine:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:engine:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:engine:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:engine:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:simulation:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:simulation:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:simulation:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:mergeAndroidMainJavaResource
+> Task :shared:simulation:processAndroidMainManifest UP-TO-DATE
+> Task :shared:syncAndroidMainLibJars
+> Task :shared:bundleAndroidMainLocalLintAar
+> Task :shared:simulation:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:simulation:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:simulation:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:simulation:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:wled:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:wled:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:wled:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:wled:processAndroidMainManifest UP-TO-DATE
+> Task :shared:wled:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:wled:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:wled:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:wled:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:networking:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:networking:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:networking:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:networking:processAndroidMainManifest UP-TO-DATE
+> Task :shared:networking:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:networking:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:networking:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:networking:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:tempo:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:tempo:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:tempo:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:tempo:processAndroidMainManifest UP-TO-DATE
+> Task :shared:tempo:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:tempo:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:tempo:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:tempo:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:subscription:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:subscription:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:subscription:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:subscription:processAndroidMainManifest UP-TO-DATE
+> Task :shared:subscription:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:subscription:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:subscription:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:subscription:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:vision:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:vision:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:vision:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:vision:processAndroidMainManifest UP-TO-DATE
+> Task :shared:vision:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:vision:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:vision:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:vision:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:core:checkAndroidMainAarMetadata UP-TO-DATE
+> Task :shared:core:extractAndroidMainAnnotations UP-TO-DATE
+> Task :shared:core:generateAndroidMainEmptyResourceFiles UP-TO-DATE
+> Task :shared:core:processAndroidMainManifest UP-TO-DATE
+> Task :shared:core:processAndroidMainJavaRes UP-TO-DATE
+> Task :shared:core:mergeAndroidMainJavaResource UP-TO-DATE
+> Task :shared:core:syncAndroidMainLibJars UP-TO-DATE
+> Task :shared:core:bundleAndroidMainLocalLintAar UP-TO-DATE
+> Task :shared:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:createFullJarAndroidMain
+> Task :shared:preAndroidHostTestBuild UP-TO-DATE
+> Task :shared:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:agent:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:agent:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:agent:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:core:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:core:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:core:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:engine:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:engine:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:engine:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:networking:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:networking:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:networking:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:simulation:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:simulation:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:simulation:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:subscription:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:subscription:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:subscription:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:tempo:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:tempo:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:tempo:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:vision:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:vision:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:vision:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:wled:bundleAndroidMainClassesToRuntimeJar UP-TO-DATE
+> Task :shared:wled:createFullJarAndroidMain UP-TO-DATE
+> Task :shared:wled:prepareLintJarForPublish UP-TO-DATE
+> Task :shared:lintAnalyzeAndroidHostTest
+
+[Incubating] Problems report is available at: file:///app/build/reports/problems/problems-report.html
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
+
+BUILD SUCCESSFUL in 1m 3s
+161 actionable tasks: 15 executed, 146 up-to-date
+Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.3.1/userguide/configuration_cache_enabling.html

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -38,6 +38,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -84,6 +87,7 @@ fun PixelIconButton(
     modifier: Modifier = Modifier,
     glowing: Boolean = false,
     enabled: Boolean = true,
+    contentDescription: String? = null,
     content: @Composable () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -119,6 +123,13 @@ fun PixelIconButton(
             }
             .clip(shape)
             .background(bgColor, shape)
+            .let { mod ->
+                if (contentDescription != null) {
+                    mod.semantics { this.contentDescription = contentDescription }
+                } else {
+                    mod
+                }
+            }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
@@ -194,7 +194,7 @@ fun PixelShowcaseScreen() {
 
                             // Icon buttons
                             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                PixelIconButton(onClick = {}) {
+                                PixelIconButton(onClick = {}, contentDescription = "Star") {
                                     Icon(
                                         imageVector = Icons.Filled.Star,
                                         contentDescription = "Star",
@@ -203,6 +203,7 @@ fun PixelShowcaseScreen() {
                                 }
                                 PixelIconButton(
                                     onClick = {},
+                                    contentDescription = "Favorite",
                                     glowing = true,
                                 ) {
                                     Icon(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -82,7 +82,7 @@ fun SettingsScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PixelIconButton(onClick = onBack) {
+                PixelIconButton(onClick = onBack, contentDescription = "Go back") {
                     Text(
                         text = "\u25C0",
                         style = MaterialTheme.typography.bodyLarge,
@@ -547,7 +547,7 @@ private fun FixtureProfileRow(
         )
 
         // Edit button
-        PixelIconButton(onClick = onEdit) {
+        PixelIconButton(onClick = onEdit, contentDescription = "Edit") {
             Text(
                 text = "\u270E",
                 style = MaterialTheme.typography.bodySmall,
@@ -557,7 +557,7 @@ private fun FixtureProfileRow(
 
         // Delete button (only for user-created profiles)
         if (!isBuiltIn) {
-            PixelIconButton(onClick = onDelete) {
+            PixelIconButton(onClick = onDelete, contentDescription = "Delete") {
                 Text(
                     text = "\u2716",
                     style = MaterialTheme.typography.bodySmall,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
@@ -251,6 +251,7 @@ private fun LayerPanelHeader(
         // Add button
         PixelIconButton(
             onClick = onAddLayer,
+            contentDescription = "Add Layer",
             modifier = Modifier.size(28.dp),
         ) {
             Text(
@@ -450,6 +451,7 @@ private fun LayerActions(
         // Move Up
         PixelIconButton(
             onClick = onMoveUp,
+            contentDescription = "Move Layer Up",
             enabled = layerIndex > 0,
             modifier = Modifier.size(32.dp),
         ) {
@@ -465,6 +467,7 @@ private fun LayerActions(
         // Move Down
         PixelIconButton(
             onClick = onMoveDown,
+            contentDescription = "Move Layer Down",
             enabled = layerIndex < layerCount - 1,
             modifier = Modifier.size(32.dp),
         ) {
@@ -480,6 +483,7 @@ private fun LayerActions(
         // Delete
         PixelIconButton(
             onClick = onDelete,
+            contentDescription = "Delete Layer",
             modifier = Modifier.size(32.dp),
         ) {
             Text(


### PR DESCRIPTION
💡 **What**: Added a `contentDescription` parameter to the `PixelIconButton` composable and applied it via `Modifier.semantics`. Updated all instances of `PixelIconButton` to provide descriptive text for their actions (e.g., "Go back", "Delete Layer", "Star").
🎯 **Why**: `PixelIconButton` is a custom composable built on top of `Box` and `.clickable()`. Unlike Material's `IconButton`, it did not expose or apply accessibility labels. This prevented screen readers from interpreting the action of these icon-only buttons, degrading accessibility for users relying on assistive technologies.
📸 **Before/After**: (Visual appearance remains unchanged. Changes are purely semantic to the accessibility tree.)
♿ **Accessibility**: Icon-only buttons across Settings, Layer Editor, and Showcase now have ARIA-equivalent text, allowing screen readers to properly announce their function (e.g., "Button, Add Layer").

---
*PR created automatically by Jules for task [8827157685918724415](https://jules.google.com/task/8827157685918724415) started by @srMarlins*