### PR TITLE
⚡ Bolt: [performance improvement] Avoid auto-boxing in BlobDetector flood-fill and optimize filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Avoid Collections and Auto-Boxing in Vision Hot Paths
+**Learning:** Using `ArrayDeque<Int>` in recursive/flood-fill vision algorithms (like `BlobDetector.floodFill`) causes significant primitive auto-boxing allocations (Int to Integer) on each pixel. Additionally, chaining `.filter {}.map {}` causes double traversal and an extra list allocation.
+**Action:** Pre-allocate primitive arrays (e.g., `IntArray` sized to `w*h`) and track a `stackSize` index manually for DFS algorithms. Use `.mapNotNull {}` instead of `.filter.map` to perform operations in a single traversal with fewer allocations.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,9 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        // Pre-allocate a primitive array stack to avoid ArrayDeque<Int> auto-boxing allocations
+        val stack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,31 +58,34 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
         }
 
-        // Convert accumulators to DetectedBlob, filter by min size
+        // Convert accumulators to DetectedBlob, mapNotNull avoids filter+map double traversal
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else {
+                    null
+                }
             }
             .sortedByDescending { it.totalBrightness }
     }
 
     /**
-     * Iterative flood-fill using an explicit stack to avoid stack overflow
-     * on large blobs. Uses 4-connectivity (up/down/left/right).
+     * Iterative flood-fill using an explicit pre-allocated stack to avoid stack overflow
+     * and auto-boxing on large blobs. Uses 4-connectivity (up/down/left/right).
      */
     private fun floodFill(
         pixels: FloatArray,
@@ -89,15 +95,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +119,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
### 💡 What
Replaced the `ArrayDeque<Int>` used in the `floodFill` algorithm of `BlobDetector` with a pre-allocated primitive `IntArray`. Combined `.filter` and `.map` operations into a single `.mapNotNull` when processing connected components.

### 🎯 Why
In a performance-critical path like camera frame analysis (`BlobDetector`), `ArrayDeque<Int>` causes severe primitive auto-boxing allocations (converting `Int` to `java.lang.Integer`) for every pixel processed in a blob. This produces significant GC pressure. Furthermore, chaining `.filter` and `.map` creates an unnecessary intermediate list allocation and requires iterating over the components twice.

### 📊 Impact
- Eliminates potentially thousands of object allocations per frame by keeping the flood-fill stack purely primitive.
- Reduces CPU cycles and GC pressure.
- Saves one intermediate list allocation during blob filtering.

### 🔬 Measurement
Run `./gradlew :shared:vision:testAndroidHostTest` to verify that blob detection logic is unchanged. Profile the app using Android Studio profiler to observe reduced allocation rates when processing vision inputs.

---
*PR created automatically by Jules for task [6998571817144932071](https://jules.google.com/task/6998571817144932071) started by @srMarlins*