### PR TITLE
⚡ Bolt: [performance improvement] Eliminate autoboxing and intermediate collections in BlobDetector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2024-04-17 - Avoid Intermediate Collections and Autoboxing in Vision Hot Paths
+**Learning:** The `BlobDetector.floodFill` processing image frames frequently accesses generic collections like `ArrayDeque<Int>`, causing primitive auto-boxing and intermediate object creations. Combining `.filter {}.map {}` into `.mapNotNull {}` reduces GC pressure and CPU cycles.
+**Action:** In performance-critical vision logic, replace `ArrayDeque` with pre-allocated primitive arrays (like `IntArray`) as stacks, and combine sequential collection operators to minimize allocations.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -44,6 +44,7 @@ class BlobDetector(
         // Label array: 0 = unlabeled, >0 = component label
         val labels = IntArray(w * h)
         var nextLabel = 1
+        val stack = IntArray(w * h)
 
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
@@ -55,7 +56,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
@@ -63,16 +64,18 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            // Optimized: Merged filter & map, avoided intermediate collections
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +92,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +116,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 What: Replaced the `ArrayDeque<Int>` in `floodFill` with a pre-allocated primitive `IntArray` stack, and combined `.filter().map()` into a single `.mapNotNull()` inside the `detect` method.
🎯 Why: `BlobDetector` operates in a hot loop on image frames. `ArrayDeque<Int>` causes auto-boxing of `Int` to `Integer` objects for every processed pixel, creating significant GC pressure. Splitting `.filter` and `.map` creates unnecessary intermediate lists.
📊 Impact: Eliminates object allocation inside the `floodFill` path (O(1) allocation down from O(N)), drastically reducing garbage collection pauses during vision processing.
🔬 Measurement: Verify by running vision tests (`./gradlew :shared:vision:testAndroidHostTest`) and profiling memory allocations during continuous scanning.

---
*PR created automatically by Jules for task [15836744833304277146](https://jules.google.com/task/15836744833304277146) started by @srMarlins*