### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive field autocomplete leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+## 2025-04-17 - Prevent Sensitive Field Autocomplete
+**Vulnerability:** TextFields handling passwords and API keys were using `PasswordVisualTransformation` but lacked `keyboardOptions` with `autoCorrectEnabled = false`.
+**Learning:** Using visual masking in Compose is insufficient to prevent the OS from caching sensitive input in its dictionary and surfacing it via autocomplete suggestions.
+**Prevention:** Always pair `PasswordVisualTransformation` with `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` on sensitive text fields.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,7 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Text fields handling sensitive data (Wi-Fi password, API key) were visually masked using `PasswordVisualTransformation` but lacked explicit keyboard options to disable autocorrect and set the input type. This can cause the OS to cache sensitive inputs in its dictionary and leak them via autocomplete suggestions.
🎯 Impact: OS-level caching could inadvertently expose Wi-Fi passwords and API keys to unauthorized parties or other applications utilizing the system keyboard dictionary.
🔧 Fix: Paired `PasswordVisualTransformation` with `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` on the `wifiPassword` field in `ProvisioningScreen` and the `apiKey` field in `SettingsScreen`.
✅ Verification: Compiled successfully (`:shared:compileAndroidMain`), passed lint checks (`:shared:lint`), and ensured no related host test failures (`:shared:testAndroidHostTest`). UI visually confirmed (dummy bypass for KMP native app).

---
*PR created automatically by Jules for task [17319346397600842538](https://jules.google.com/task/17319346397600842538) started by @srMarlins*