### PR TITLE
🎨 Palette: Improve PixelSwitch accessibility states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Improve PixelSwitch Accessibility
+**Learning:** The custom `PixelSwitch` used `Modifier.clickable(role = Role.Switch)`, which identifies the role but fails to announce its current 'On' or 'Off' state to screen readers.
+**Action:** Replaced `clickable` with `Modifier.toggleable` (conditionally applied using `.let` to handle the nullable callback), which properly sets semantics for both the role and the value state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +55,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                mod
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What:** Improved the accessibility semantics for the custom `PixelSwitch` component by replacing `Modifier.clickable` with `Modifier.toggleable`.

🎯 **Why:** The previous implementation used `clickable(role = Role.Switch)`, which told screen readers that the element was a switch but failed to announce whether it was currently "On" or "Off". This made the component fundamentally inaccessible to non-visual users as they could not perceive its current state.

📸 **Before/After:** No visual changes. This is purely a semantic accessibility improvement for screen readers.

♿ **Accessibility:** Screen readers (TalkBack/VoiceOver) will now correctly announce the component's checked state ("Switch, On" or "Switch, Off") alongside its role, rather than just "Switch". The modifier correctly respects the enabled state and nullable callbacks.

---
*PR created automatically by Jules for task [11486894518485669499](https://jules.google.com/task/11486894518485669499) started by @srMarlins*