### PR TITLE
⚡ Bolt: [performance improvement] Minimize object allocations in EngineController and PreGenerationService hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2025-04-19 - EffectParams Allocation Optimization in Engine Controller Hot Path
+**Learning:** In the `RealEngineController.kt` and `PreGenerationService.kt` hot paths, iterating through Map entries and using `fold` to build immutable `EffectParams` via sequential `.with()` calls incurs $O(N)$ redundant allocations and map copies.
+**Action:** Replace `entries.fold(EffectParams.EMPTY) { acc, (k, v) -> acc.with(k, v) }` with a direct `$O(1)$ allocation by using the `EffectParams` constructor wrapper around the source Map directly, passing the map reference without duplicating entries.

--- a/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/controller/RealEngineController.kt
+++ b/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/controller/RealEngineController.kt
@@ -37,9 +37,7 @@ class RealEngineController(
         val effect = effectRegistry.get(effectId) ?: return false
 
         // Build EffectParams from the float map
-        val effectParams = params.entries.fold(EffectParams.EMPTY) { acc, (key, value) ->
-            acc.with(key, value)
-        }
+        val effectParams = EffectParams(params)
 
         // Synchronized: layerCount→addLayer→layers[layer]→setLayer must be atomic
         synchronized(lock) {
@@ -109,9 +107,7 @@ class RealEngineController(
         // the engine seeing a partially-applied scene.
         val newLayers = scene.layers.mapNotNull { layerConfig ->
             val effect = effectRegistry.get(layerConfig.effectId) ?: return@mapNotNull null
-            val params = layerConfig.params.entries.fold(EffectParams.EMPTY) { acc, (key, value) ->
-                acc.with(key, value)
-            }
+            val params = EffectParams(layerConfig.params)
             val blendMode = try {
                 BlendMode.valueOf(layerConfig.blendMode)
             } catch (_: IllegalArgumentException) {

--- a/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
+++ b/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
@@ -112,7 +112,7 @@ class PreGenerationService(
         val layers = template.layers.map { layer ->
             EffectLayerConfig(
                 effectId = layer.effectId,
-                params = layer.params.entries.fold(EffectParams.EMPTY) { acc, (k, v) -> acc.with(k, v) },
+                params = EffectParams(layer.params),
                 blendMode = BlendMode.valueOf(layer.blendMode),
                 opacity = layer.opacity,
                 enabled = true


### PR DESCRIPTION
### 💡 What
Modified `RealEngineController.kt` and `PreGenerationService.kt` to construct `EffectParams` using `EffectParams(params)` rather than iterating over map entries via `fold` and invoking `.with()`.

### 🎯 Why
In performance-critical hot paths like the engine controller (applying scenes) and pre-generation batch processing, the existing approach incurred $O(N)$ redundant allocations (creating new `EffectParams` instances) and $O(N^2)$ map-copying overhead for every layer parameter map. This caused unnecessary garbage collection pressure.

### 📊 Impact
- Reduces memory allocations during scene generation and real-time engine application from $O(N)$ intermediate objects per layer down to a single $O(1)$ allocation.
- Reduces CPU overhead associated with copying small maps repeatedly.
- Decreases GC pause durations under heavy load.

### 🔬 Measurement
Run `./gradlew :shared:agent:testAndroidHostTest` to verify that functionality remains correct. You can visually verify memory impact via a profiler (e.g., Android Studio Memory Profiler) while triggering frequent scene changes; fewer `EffectParams` and `Map` instance allocations will be observed on the heap.

---
*PR created automatically by Jules for task [7527403310439985518](https://jules.google.com/task/7527403310439985518) started by @srMarlins*