### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve PixelSwitch screen reader accessibility
+**Learning:** In Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` properly identifies the element as a switch but fails to announce its current 'On' or 'Off' state to screen readers. `Modifier.toggleable` must be used instead because it natively manages semantics for both the role and the toggled state.
+**Action:** When implementing custom interactive switch or checkbox components, always use `toggleable(value, onValueChange, role)` rather than a simple `clickable` modifier, wrapping it in a `.let` block if the callback is nullable to properly handle disabled states.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +55,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                mod
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What:** Improved screen reader semantics for the `PixelSwitch` component by replacing `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable`.
🎯 **Why:** While `clickable` with `Role.Switch` identifies the element correctly, it fails to announce the current toggled state ("On" or "Off") to screen reader users in Compose Multiplatform. `toggleable` natively provides both the role and state announcements.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now correctly read the state of `PixelSwitch` interactives.

**Testing:**
- Ran `./gradlew :shared:compileAndroidMain` to verify compilation.
- Ran `./gradlew :shared:lint` to verify code format.
- Ran tests via `:shared:testAndroidHostTest` (Pre-existing failures in SetupViewModel noted).

---
*PR created automatically by Jules for task [9078645461046512232](https://jules.google.com/task/9078645461046512232) started by @srMarlins*