### PR TITLE
🎨 Palette: Fix PixelSwitch screen reader state announcements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-04-20 - Custom Compose Switch Accessibility
+**Learning:** In Compose Multiplatform, using `clickable(role = Role.Switch)` on a custom switch correctly identifies it as a switch, but screen readers will not announce its current "On" or "Off" state.
+**Action:** Always use `Modifier.toggleable(value = checked, ...)` for custom switches, checking for nullable `onCheckedChange` callbacks via `.let` to maintain proper interaction behavior, as it inherently reports both the switch role and the current value.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +55,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { base ->
+            if (onCheckedChange != null) {
+                base.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = { onCheckedChange.invoke(it) },
+                    role = Role.Switch
+                )
+            } else {
+                base
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What**: Replaced the `clickable` modifier with `toggleable` in the `PixelSwitch` UI component, and handled nullable `onCheckedChange` callbacks securely.
🎯 **Why**: Using `clickable(role = Role.Switch)` tells a screen reader it's a switch but doesn't announce its checked/unchecked state. `toggleable` properly reports both the role and its current state, making the component fully accessible.
📸 **Before/After**: N/A (Semantic change only, visually identical).
♿ **Accessibility**: Screen readers will now correctly read out whether the switch is currently on or off when navigating to it.

---
*PR created automatically by Jules for task [9645820999022883869](https://jules.google.com/task/9645820999022883869) started by @srMarlins*