### PR TITLE
⚡ Bolt: Hoist invariant calculations out of inner rendering map loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2025-03-01 - Hoist Invariant Calculations in Rendering Loops
+**Learning:** In Compose UI hot paths like `TopDownEditor.kt`, computations that depend solely on outer scope properties (like `size.width / 2f`) can trigger thousands of redundant arithmetic operations if placed inside `.map {}` closures over large collections.
+**Action:** Always hoist loop-invariant calculations outside of collection mapping closures in performance-critical drawing loops to minimize repeated arithmetic and property access overhead.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/renderer/TopDownEditor.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/renderer/TopDownEditor.kt
@@ -320,9 +320,9 @@ fun TopDownEditor(
             }
 
             // Update screen positions for hit testing (transform-adjusted)
+            val pivotX = size.width / 2f
+            val pivotY = size.height / 2f
             fixtureScreenPositions = positions.map { pos ->
-                val pivotX = size.width / 2f
-                val pivotY = size.height / 2f
                 Offset(
                     (pos.x - pivotX) * zoom + pivotX + panOffset.x,
                     (pos.y - pivotY) * zoom + pivotY + panOffset.y,


### PR DESCRIPTION
💡 What: Hoisted loop-invariant `pivotX` and `pivotY` calculations outside of the `positions.map` closure in `TopDownEditor.kt`.
🎯 Why: In a hot UI rendering path, evaluating `size.width / 2f` and `size.height / 2f` inside a mapping function over a collection means performing redundant arithmetic and property accesses thousands of times per second (e.g., 60fps * number of fixtures).
📊 Impact: Reduces redundant arithmetic operations and property reads during the hit-testing map phase from $O(N)$ to $O(1)$, slightly reducing CPU overhead during dragging and interaction loops.
🔬 Measurement: Verify that interactive drag performance and hover states in the fixture map remain smooth and performant. No visual functionality changed.

---
*PR created automatically by Jules for task [3996505264053948147](https://jules.google.com/task/3996505264053948147) started by @srMarlins*