### PR TITLE
⚡ Bolt: Optimize BlobDetector flood-fill and allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-04-21 - Avoid auto-boxing and redundant list allocations in `BlobDetector`
+**Learning:** In the `BlobDetector` hot path within the vision module, using generic collections like `ArrayDeque<Int>` for the flood-fill stack caused primitive auto-boxing (Int to Integer) and unnecessary intermediate object creations. Furthermore, chained `filter` and `map` operations produced redundant intermediate list allocations.
+**Action:** Replaced `ArrayDeque<Int>` with a pre-allocated primitive array (`IntArray`) to avoid auto-boxing and combined `filter` and `map` into a single `mapNotNull` pass to eliminate intermediate collection allocations in performance-critical paths.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,10 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        // Pre-allocate primitive array stack for flood-fill to avoid auto-boxing
+        // and per-blob allocations associated with ArrayDeque<Int>.
+        val stack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,24 +59,26 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, stack)
                     components[label] = acc
                 }
             }
         }
 
         // Convert accumulators to DetectedBlob, filter by min size
+        // Combine filter and map to avoid redundant intermediate list allocations
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +95,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +119,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 **What**: Optimized `BlobDetector.kt` to avoid intermediate collection allocations and primitive auto-boxing during flood-fill component connection and filtering.
🎯 **Why**: The vision module processes frames frequently, and `BlobDetector` is a hot path. `ArrayDeque<Int>` causes primitive `Int`s to be auto-boxed into `Integer` objects. Furthermore, chaining `.filter` and `.map` creates unnecessary intermediate `ArrayList` collections. This creates GC pressure and potential frame drops.
📊 **Impact**: Eliminates `N` allocations of `ArrayDeque` per frame (where `N` is the number of detected blobs) and limits stack memory usage strictly to the size of the image. It also eliminates the creation of an intermediate `ArrayList` of accumulators during the final stage of blob detection, providing O(1) allocation overhead during component extraction.
🔬 **Measurement**: To verify the improvement, measure GC pause frequency and total memory allocated per second during continuous blob detection on a noisy input source. Tests verify no logic changes via `./gradlew :shared:vision:testAndroidHostTest`.

---
*PR created automatically by Jules for task [12640325830948839138](https://jules.google.com/task/12640325830948839138) started by @srMarlins*