### PR TITLE
🎨 Palette: Improve screen reader accessibility for PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-21 - Switch Accessibility via Toggleable
+**Learning:** Using `Modifier.clickable(role = Role.Switch)` properly identifies a component as a switch to screen readers but fails to announce its current 'On'/'Off' state. `Modifier.toggleable(value = checked)` correctly manages both the role and the value state for a11y.
+**Action:** Always prefer `toggleable` over `clickable` for custom switch/checkbox UI components to ensure accurate state announcements.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +55,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { base ->
+            if (onCheckedChange != null) {
+                base.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                base
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 **What:** Replaced `Modifier.clickable(role = Role.Switch)` with `Modifier.toggleable` in the `PixelSwitch` component. Conditionally applied the modifier using a `.let` block so it correctly remains non-interactive when the `onCheckedChange` callback is null.
🎯 **Why:** Using `clickable` with a switch role properly identifies the element as a switch but fails to announce its current 'On'/'Off' state to screen readers. `toggleable` properly sets the semantics for both the role and the value state, providing a much more intuitive and accessible experience for screen reader users.
📸 **Before/After:** Not a visual change; affects screen reader announcements only.
♿ **Accessibility:** Significantly improves a11y by ensuring custom switch components accurately report their checked/unchecked state to assistive technologies.

---
*PR created automatically by Jules for task [9076073013397706758](https://jules.google.com/task/9076073013397706758) started by @srMarlins*