### PR TITLE
⚡ Bolt: [performance improvement] Reduce GC pressure in BlobDetector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-03-01 - Optimize BlobDetector by reducing GC pressure
+**Learning:** Found that using generic collections (`ArrayDeque<Int>`) for primitive types in high-frequency hot paths (like vision processing `floodFill`) causes significant auto-boxing overhead (Int -> java.lang.Integer) and heavy GC pressure.
+**Action:** Replaced `ArrayDeque<Int>` with a pre-allocated single `IntArray` shared across the stack for `floodFill` in `BlobDetector`. Also replaced `filter` + `map` chain with `mapNotNull` to eliminate intermediate lists. Next time, always check for generic primitive collections in performance-critical loops.

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -48,6 +48,10 @@ class BlobDetector(
         // Accumulator per label: (sumX, sumY, sumBrightness, count)
         val components = mutableMapOf<Int, BlobAccumulator>()
 
+        // Pre-allocate a single primitive array for the flood-fill stack to avoid auto-boxing
+        // ArrayDeque<Int> and reduce GC pressure in this hot path.
+        val floodFillStack = IntArray(w * h)
+
         // Single-pass flood-fill CCL with 4-connectivity
         for (y in 0 until h) {
             for (x in 0 until w) {
@@ -55,7 +59,7 @@ class BlobDetector(
                 if (pixels[idx] >= brightnessThreshold && labels[idx] == 0) {
                     val label = nextLabel++
                     val acc = BlobAccumulator()
-                    floodFill(pixels, labels, w, h, x, y, label, acc)
+                    floodFill(pixels, labels, w, h, x, y, label, acc, floodFillStack)
                     components[label] = acc
                 }
             }
@@ -63,16 +67,17 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else null
             }
             .sortedByDescending { it.totalBrightness }
     }
@@ -89,15 +94,16 @@ class BlobDetector(
         startX: Int,
         startY: Int,
         label: Int,
-        acc: BlobAccumulator
+        acc: BlobAccumulator,
+        stack: IntArray
     ) {
-        val stack = ArrayDeque<Int>()
+        var stackSize = 0
         val startIdx = startY * w + startX
-        stack.addLast(startIdx)
+        stack[stackSize++] = startIdx
         labels[startIdx] = label
 
-        while (stack.isNotEmpty()) {
-            val idx = stack.removeLast()
+        while (stackSize > 0) {
+            val idx = stack[--stackSize]
             val x = idx % w
             val y = idx / w
             val brightness = pixels[idx]
@@ -112,28 +118,28 @@ class BlobDetector(
                 val nIdx = idx + 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (x - 1 >= 0) {
                 val nIdx = idx - 1
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y + 1 < h) {
                 val nIdx = idx + w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
             if (y - 1 >= 0) {
                 val nIdx = idx - w
                 if (labels[nIdx] == 0 && pixels[nIdx] >= brightnessThreshold) {
                     labels[nIdx] = label
-                    stack.addLast(nIdx)
+                    stack[stackSize++] = nIdx
                 }
             }
         }


### PR DESCRIPTION
💡 What: Replaced `ArrayDeque<Int>` with a pre-allocated `IntArray` for flood fill stack and replaced `.filter {}.map {}` with `.mapNotNull {}`.
🎯 Why: Using generic collections for primitives in hot paths causes auto-boxing overhead and high GC pressure. Intermediate collections also increase memory churn.
📊 Impact: Significantly reduces object allocations per frame by avoiding `java.lang.Integer` boxing and intermediate list creations during vision processing.
🔬 Measurement: Observe memory profiling and GC pause times when camera tracking is active to verify reduced memory churn.

---
*PR created automatically by Jules for task [7482189170746517726](https://jules.google.com/task/7482189170746517726) started by @srMarlins*