### PR TITLE
⚡ Bolt: Optimize EffectParams creation in PreGenerationService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2025-02-18 - Avoid O(N^2) Map Copies When Creating EffectParams
+**Learning:** In `PreGenerationService.kt`, batch scene generation was using `.fold(EffectParams.EMPTY) { acc, (k, v) -> acc.with(k, v) }` to build `EffectParams` from a generic map of primitive parameters. Because `EffectParams.with` creates a completely new map on every single invocation, this caused $O(N)$ redundant allocations and $O(N^2)$ map-copying operations per layer, creating significant garbage collection pressure during rapid scene generation.
+**Action:** Replace `fold` loops with direct `EffectParams(map)` constructor calls. Passing the source map directly delegates map handling to the constructor, reducing the operation complexity from $O(N^2)$ to $O(1)$ allocation overhead and dramatically improving hot path performance.

--- a/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
+++ b/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
@@ -112,7 +112,7 @@ class PreGenerationService(
         val layers = template.layers.map { layer ->
             EffectLayerConfig(
                 effectId = layer.effectId,
-                params = layer.params.entries.fold(EffectParams.EMPTY) { acc, (k, v) -> acc.with(k, v) },
+                params = EffectParams(layer.params),
                 blendMode = BlendMode.valueOf(layer.blendMode),
                 opacity = layer.opacity,
                 enabled = true


### PR DESCRIPTION
💡 What: Replaced a `fold` loop that repeatedly copied maps to build an `EffectParams` instance with a direct constructor call passing the source map.

🎯 Why: The original `acc.with(k, v)` method creates a completely new `Map` on every single iteration. For a map of size $N$, this results in $O(N)$ allocations and $O(N^2)$ entry copies. Since `EffectParams` internally accepts a `Map<String, Any>` and Kotlin maps are covariant in values, we can pass the source `Map<String, Float>` directly to the constructor in $O(1)$ operations, eliminating the garbage collection bottleneck during rapid batch scene generation.

📊 Impact: Reduces temporary map object allocations and entry copying from $O(N^2)$ to $O(1)$ per effect layer during generation.

🧪 Measurement: Code inspection confirms `PreGenerationService.generateSceneForGenre` no longer invokes `.with()` repeatedly. All compilation, linting, and host tests pass.

---
*PR created automatically by Jules for task [1193002106167195234](https://jules.google.com/task/1193002106167195234) started by @srMarlins*