### PR TITLE
🛡️ Sentinel: [HIGH] Fix API key keyboard type to prevent OS caching

### DIFF
--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -744,6 +744,7 @@ private fun AgentSection(
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
                 modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
             )
 
             // Model selector


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API key input field in the settings screen did not specify a password keyboard type. This could allow the underlying OS keyboard to cache the sensitive token in its dictionary and suggest it via autocomplete in other applications or contexts.
🎯 Impact: OS keyboard dictionary cache poisoning, leading to accidental leakage of secrets.
🛠️ Fix: Added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to the `PixelTextField` for the API Key in `SettingsScreen.kt`.
✅ Verification: The `:shared:lint`, `:shared:compileAndroidMain`, and `:shared:testAndroidHostTest` tasks execute successfully. Visually verify the keyboard changes when the input field is focused on a device.

---
*PR created automatically by Jules for task [15301501464863139563](https://jules.google.com/task/15301501464863139563) started by @srMarlins*