### PR TITLE
🎨 Palette: Add ARIA/semantics labels to custom PixelIconButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Added ARIA/semantics labels to custom PixelIconButton
+**Learning:** Custom interactive components like `PixelIconButton` built with `Box` and `clickable` do not inherit accessibility traits automatically; they must explicitly expose and apply `contentDescription` via the `semantics` modifier.
+**Action:** Always add a `contentDescription` parameter to custom icon-only UI components and apply it within `Modifier.semantics` before the `clickable` modifier.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -82,6 +84,7 @@ import com.chromadmx.ui.theme.PixelShape
 fun PixelIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     glowing: Boolean = false,
     enabled: Boolean = true,
     content: @Composable () -> Unit,
@@ -119,6 +122,11 @@ fun PixelIconButton(
             }
             .clip(shape)
             .background(bgColor, shape)
+            .semantics {
+                if (contentDescription != null) {
+                    this.contentDescription = contentDescription
+                }
+            }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
@@ -194,7 +194,7 @@ fun PixelShowcaseScreen() {
 
                             // Icon buttons
                             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                PixelIconButton(onClick = {}) {
+                                PixelIconButton(onClick = {}, contentDescription = "Star") {
                                     Icon(
                                         imageVector = Icons.Filled.Star,
                                         contentDescription = "Star",
@@ -203,6 +203,7 @@ fun PixelShowcaseScreen() {
                                 }
                                 PixelIconButton(
                                     onClick = {},
+                                    contentDescription = "Favorite",
                                     glowing = true,
                                 ) {
                                     Icon(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -82,7 +82,7 @@ fun SettingsScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PixelIconButton(onClick = onBack) {
+                PixelIconButton(onClick = onBack, contentDescription = "Back") {
                     Text(
                         text = "\u25C0",
                         style = MaterialTheme.typography.bodyLarge,
@@ -547,7 +547,7 @@ private fun FixtureProfileRow(
         )
 
         // Edit button
-        PixelIconButton(onClick = onEdit) {
+        PixelIconButton(onClick = onEdit, contentDescription = "Edit Profile") {
             Text(
                 text = "\u270E",
                 style = MaterialTheme.typography.bodySmall,
@@ -557,7 +557,7 @@ private fun FixtureProfileRow(
 
         // Delete button (only for user-created profiles)
         if (!isBuiltIn) {
-            PixelIconButton(onClick = onDelete) {
+            PixelIconButton(onClick = onDelete, contentDescription = "Delete Profile") {
                 Text(
                     text = "\u2716",
                     style = MaterialTheme.typography.bodySmall,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
@@ -251,6 +251,7 @@ private fun LayerPanelHeader(
         // Add button
         PixelIconButton(
             onClick = onAddLayer,
+            contentDescription = "Add Effect Layer",
             modifier = Modifier.size(28.dp),
         ) {
             Text(
@@ -450,6 +451,7 @@ private fun LayerActions(
         // Move Up
         PixelIconButton(
             onClick = onMoveUp,
+            contentDescription = "Move Layer Up",
             enabled = layerIndex > 0,
             modifier = Modifier.size(32.dp),
         ) {
@@ -465,6 +467,7 @@ private fun LayerActions(
         // Move Down
         PixelIconButton(
             onClick = onMoveDown,
+            contentDescription = "Move Layer Down",
             enabled = layerIndex < layerCount - 1,
             modifier = Modifier.size(32.dp),
         ) {
@@ -480,6 +483,7 @@ private fun LayerActions(
         // Delete
         PixelIconButton(
             onClick = onDelete,
+            contentDescription = "Delete Layer",
             modifier = Modifier.size(32.dp),
         ) {
             Text(


### PR DESCRIPTION
💡 **What:** Added a `contentDescription` parameter to the custom `PixelIconButton` component and applied it via `Modifier.semantics`. Updated existing usages of `PixelIconButton` across the app (Settings, Stage Editor, Showcase) to provide meaningful descriptions.
🎯 **Why:** Custom interactive components built with a `Box` and `clickable` modifier do not automatically infer or inherit accessibility traits. Without a `contentDescription`, screen readers simply announce "button" or remain silent when navigating to icon-only buttons, making the interface unusable for visually impaired users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Icon-only buttons (like Back, Edit, Delete, Move Up/Down, etc.) are now correctly announced by screen readers with their respective actions.

---
*PR created automatically by Jules for task [10831894955458787776](https://jules.google.com/task/10831894955458787776) started by @srMarlins*