### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure Android backup configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+
+## 2024-05-15 - Disable ADB App Backups
+**Vulnerability:** Android application configured with `android:allowBackup="true"`.
+**Learning:** This allows full app data extraction via ADB, potentially leaking sensitive information.
+**Prevention:** Always set `android:allowBackup="false"` in the `AndroidManifest.xml` to prevent unauthorized physical data extraction.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name=".ChromaDMXApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.ChromaDMX">


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The Android app was configured with `android:allowBackup="true"`.
🎯 **Impact**: This setting allows full application data extraction via ADB backup (`adb backup`), potentially exposing sensitive information such as local database content, SharedPreferences, or cached API keys to unauthorized users with physical access.
🔧 **Fix**: Disabled auto-backups by setting `android:allowBackup="false"` in `android/app/src/main/AndroidManifest.xml`.
✅ **Verification**: 
- Verified `android:allowBackup="false"` in the manifest file.
- Ran `./gradlew :android:app:lintDebug` to ensure no lint warnings were triggered.
- Ran `./gradlew :android:app:testDebugUnitTest` to ensure tests continue to pass.

---
*PR created automatically by Jules for task [11660375587404296989](https://jules.google.com/task/11660375587404296989) started by @srMarlins*