### PR TITLE
🎨 Palette: [UX improvement] Add contentDescription and semantics to custom interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Compose Multiplatform Icon Button Accessibility
+**Learning:** Custom interactive containers or icon-only buttons in Compose Multiplatform must expose a `contentDescription` parameter and apply it via `Modifier.semantics { this.contentDescription = ... }` before the `clickable` modifier. This ensures they are properly announced by screen readers.
+**Action:** When creating or modifying custom interactive components like `PixelIconButton`, require a `contentDescription` in the function signature and apply it to the modifier chain. Also apply semantics for other custom clickable elements like badges or health nodes.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/NodeHealthCompact.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.chromadmx.core.model.DmxNode
@@ -46,7 +48,8 @@ fun NodeHealthCompact(
 
     Row(
         modifier = modifier
-            .clickable { onClick() }
+            .semantics { this.contentDescription = "Node Health Details" }
+            .clickable(role = androidx.compose.ui.semantics.Role.Button) { onClick() }
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -38,6 +38,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -81,6 +84,7 @@ import com.chromadmx.ui.theme.PixelShape
 @Composable
 fun PixelIconButton(
     onClick: () -> Unit,
+    contentDescription: String,
     modifier: Modifier = Modifier,
     glowing: Boolean = false,
     enabled: Boolean = true,
@@ -119,6 +123,7 @@ fun PixelIconButton(
             }
             .clip(shape)
             .background(bgColor, shape)
+            .semantics { this.contentDescription = contentDescription }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/SimulationBadge.kt
@@ -17,6 +17,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
@@ -54,7 +56,8 @@ fun SimulationBadge(
     Box(
         modifier = modifier
             .alpha(alpha)
-            .clickable(onClick = onTap)
+            .semantics { this.contentDescription = "Simulation Info" }
+            .clickable(role = androidx.compose.ui.semantics.Role.Button, onClick = onTap)
             .pixelBorder(color = NeonMagenta.copy(alpha = 0.6f), pixelSize = pixelSize)
             .background(NeonMagenta.copy(alpha = 0.25f))
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
@@ -194,7 +194,7 @@ fun PixelShowcaseScreen() {
 
                             // Icon buttons
                             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                PixelIconButton(onClick = {}) {
+                                PixelIconButton(onClick = {}, contentDescription = "Favorite") {
                                     Icon(
                                         imageVector = Icons.Filled.Star,
                                         contentDescription = "Star",
@@ -203,6 +203,7 @@ fun PixelShowcaseScreen() {
                                 }
                                 PixelIconButton(
                                     onClick = {},
+                                    contentDescription = "Play",
                                     glowing = true,
                                 ) {
                                     Icon(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -82,7 +82,7 @@ fun SettingsScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PixelIconButton(onClick = onBack) {
+                PixelIconButton(onClick = onBack, contentDescription = "Back") {
                     Text(
                         text = "\u25C0",
                         style = MaterialTheme.typography.bodyLarge,
@@ -547,7 +547,7 @@ private fun FixtureProfileRow(
         )
 
         // Edit button
-        PixelIconButton(onClick = onEdit) {
+        PixelIconButton(onClick = onEdit, contentDescription = "Edit") {
             Text(
                 text = "\u270E",
                 style = MaterialTheme.typography.bodySmall,
@@ -557,7 +557,7 @@ private fun FixtureProfileRow(
 
         // Delete button (only for user-created profiles)
         if (!isBuiltIn) {
-            PixelIconButton(onClick = onDelete) {
+            PixelIconButton(onClick = onDelete, contentDescription = "Delete") {
                 Text(
                     text = "\u2716",
                     style = MaterialTheme.typography.bodySmall,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
@@ -251,6 +251,7 @@ private fun LayerPanelHeader(
         // Add button
         PixelIconButton(
             onClick = onAddLayer,
+            contentDescription = "Add layer",
             modifier = Modifier.size(28.dp),
         ) {
             Text(
@@ -450,6 +451,7 @@ private fun LayerActions(
         // Move Up
         PixelIconButton(
             onClick = onMoveUp,
+            contentDescription = "Move layer up",
             enabled = layerIndex > 0,
             modifier = Modifier.size(32.dp),
         ) {
@@ -465,6 +467,7 @@ private fun LayerActions(
         // Move Down
         PixelIconButton(
             onClick = onMoveDown,
+            contentDescription = "Move layer down",
             enabled = layerIndex < layerCount - 1,
             modifier = Modifier.size(32.dp),
         ) {
@@ -480,6 +483,7 @@ private fun LayerActions(
         // Delete
         PixelIconButton(
             onClick = onDelete,
+            contentDescription = "Delete layer",
             modifier = Modifier.size(32.dp),
         ) {
             Text(


### PR DESCRIPTION
**💡 What**: Added a required `contentDescription` parameter to the `PixelIconButton` component and updated all usages across the app. Also applied semantic content descriptions and roles to `SimulationBadge` and `NodeHealthCompact`.
**🎯 Why**: Icon-only buttons and custom interactive elements in Compose Multiplatform are completely silent to screen readers by default. Enforcing a `contentDescription` string directly in the component signature prevents developers from forgetting to label interactive controls, drastically improving accessibility.
**📸 Before/After**: N/A - Visuals are unchanged; purely an accessibility and semantics tree enhancement.
**♿ Accessibility**: Screen readers (like TalkBack) will now accurately announce actions like "Play button", "Favorite button", "Simulation Info button", and "Add layer button" instead of reading nothing.

---
*PR created automatically by Jules for task [9616262646497070891](https://jules.google.com/task/9616262646497070891) started by @srMarlins*