### PR TITLE
⚡ Bolt: [performance improvement] Optimize DmxBridge metadata lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+
+## 2024-06-25 - Optimize DMX Conversion Loop by Pre-resolving Indexed Arrays
+**Learning:** To optimize high-frequency DMX conversion paths (40Hz-60Hz) in `DmxBridge`, pre-resolving fixture metadata—such as profiles, universe IDs, and channel starts—into indexed arrays in the constructor avoids redundant O(N) map lookups and nested property access within the per-fixture per-frame loops.
+**Action:** When working on hot paths running at high refresh rates, use parallel, pre-calculated arrays for quick, allocation-free data access over complex object lookups per loop iteration.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
@@ -22,6 +22,20 @@ class DmxBridge(
     private val fixtures: List<Fixture3D>,
     private val profiles: Map<String, FixtureProfile> = emptyMap()
 ) {
+    // Optimization: Pre-resolve metadata into indexed arrays to avoid O(N) map lookups and allocations in the 60Hz hot path.
+    private val universeIds = IntArray(fixtures.size)
+    private val channelStarts = IntArray(fixtures.size)
+    private val resolvedProfiles = Array<FixtureProfile?>(fixtures.size) { null }
+
+    init {
+        for (i in fixtures.indices) {
+            val fixture = fixtures[i].fixture
+            universeIds[i] = fixture.universeId
+            channelStarts[i] = fixture.channelStart
+            resolvedProfiles[i] = profiles[fixture.profileId] ?: BuiltInProfiles.findById(fixture.profileId)
+        }
+    }
+
     /**
      * Convert an array of per-fixture colors into per-universe DMX data.
      *
@@ -34,17 +48,17 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
+            val universeId = universeIds[i]
+            val channelStart = channelStarts[i]
             val color = colors.getOrElse(i) { Color.BLACK }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val data = universes.getOrPut(universeId) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
             if (profile != null && profile.hasRgb) {
-                writeProfileChannels(data, fixture.channelStart, profile, color)
+                writeProfileChannels(data, channelStart, profile, color)
             } else {
                 // Fallback: write as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, color)
+                writeSimpleRgb(data, channelStart, color)
             }
         }
 
@@ -65,17 +79,17 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
+            val universeId = universeIds[i]
+            val channelStart = channelStarts[i]
             val output = outputs.getOrElse(i) { FixtureOutput.DEFAULT }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val data = universes.getOrPut(universeId) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
             if (profile != null) {
-                writeProfileChannelsWithOutput(data, fixture.channelStart, profile, output)
+                writeProfileChannelsWithOutput(data, channelStart, profile, output)
             } else {
                 // Fallback: write color as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, output.color)
+                writeSimpleRgb(data, channelStart, output.color)
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-resolve fixture metadata (universe ID, channel starts, and profiles) into indexed primitive arrays within `DmxBridge` initialization.
🎯 Why: To eliminate O(N) map lookups and nested property access per-fixture per-frame within the high-frequency (60Hz) DMX conversion loops.
📊 Impact: Reduces CPU and GC pressure during the hot path, ensuring more stable frame times when rendering complex visual effects across many fixtures.
🔬 Measurement: Verified with `:shared:engine:testAndroidHostTest` and performance monitoring of the rendering loop.

---
*PR created automatically by Jules for task [17972301258327071093](https://jules.google.com/task/17972301258327071093) started by @srMarlins*