### PR TITLE
🎨 Palette: [UX improvement] Add contentDescription to PixelIconButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Initial Rules]
+**Learning:** In Compose Multiplatform, custom interactive containers or icon-only buttons must expose a `contentDescription` parameter and apply it via `Modifier.semantics { this.contentDescription = ... }` before the `clickable` modifier to ensure they are properly announced by screen readers.
+**Action:** Always add a `contentDescription: String? = null` parameter to custom icon button implementations and apply it via semantics.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelContainers.kt
@@ -53,6 +53,8 @@ import androidx.compose.ui.window.DialogProperties
 import com.chromadmx.ui.theme.ChromaAnimations
 import com.chromadmx.ui.theme.PixelDesign
 import com.chromadmx.ui.theme.PixelShape
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 
 // ============================================================================
 // PixelContainers.kt
@@ -82,6 +84,7 @@ import com.chromadmx.ui.theme.PixelShape
 fun PixelIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     glowing: Boolean = false,
     enabled: Boolean = true,
     content: @Composable () -> Unit,
@@ -119,6 +122,9 @@ fun PixelIconButton(
             }
             .clip(shape)
             .background(bgColor, shape)
+            .semantics {
+                contentDescription?.let { this.contentDescription = it }
+            }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/PixelShowcaseScreen.kt
@@ -194,7 +194,7 @@ fun PixelShowcaseScreen() {
 
                             // Icon buttons
                             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                PixelIconButton(onClick = {}) {
+                                PixelIconButton(onClick = {}, contentDescription = "Showcase default") {
                                     Icon(
                                         imageVector = Icons.Filled.Star,
                                         contentDescription = "Star",
@@ -203,6 +203,7 @@ fun PixelShowcaseScreen() {
                                 }
                                 PixelIconButton(
                                     onClick = {},
+                                    contentDescription = "Showcase glowing",
                                     glowing = true,
                                 ) {
                                     Icon(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -82,7 +82,7 @@ fun SettingsScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PixelIconButton(onClick = onBack) {
+                PixelIconButton(onClick = onBack, contentDescription = "Navigate back") {
                     Text(
                         text = "\u25C0",
                         style = MaterialTheme.typography.bodyLarge,
@@ -547,7 +547,7 @@ private fun FixtureProfileRow(
         )
 
         // Edit button
-        PixelIconButton(onClick = onEdit) {
+        PixelIconButton(onClick = onEdit, contentDescription = "Edit settings") {
             Text(
                 text = "\u270E",
                 style = MaterialTheme.typography.bodySmall,
@@ -557,7 +557,7 @@ private fun FixtureProfileRow(
 
         // Delete button (only for user-created profiles)
         if (!isBuiltIn) {
-            PixelIconButton(onClick = onDelete) {
+            PixelIconButton(onClick = onDelete, contentDescription = "Delete") {
                 Text(
                     text = "\u2716",
                     style = MaterialTheme.typography.bodySmall,

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/stage/EffectLayerPanel.kt
@@ -252,6 +252,7 @@ private fun LayerPanelHeader(
         PixelIconButton(
             onClick = onAddLayer,
             modifier = Modifier.size(28.dp),
+            contentDescription = "Add layer",
         ) {
             Text(
                 text = "+",
@@ -452,6 +453,7 @@ private fun LayerActions(
             onClick = onMoveUp,
             enabled = layerIndex > 0,
             modifier = Modifier.size(32.dp),
+            contentDescription = "Move layer up",
         ) {
             Text(
                 text = "\u2191", // ↑
@@ -467,6 +469,7 @@ private fun LayerActions(
             onClick = onMoveDown,
             enabled = layerIndex < layerCount - 1,
             modifier = Modifier.size(32.dp),
+            contentDescription = "Move layer down",
         ) {
             Text(
                 text = "\u2193", // ↓
@@ -481,6 +484,7 @@ private fun LayerActions(
         PixelIconButton(
             onClick = onDelete,
             modifier = Modifier.size(32.dp),
+            contentDescription = "Delete layer",
         ) {
             Text(
                 text = "\u2715", // ✕


### PR DESCRIPTION
💡 **What:** Added `contentDescription` parameter to the `PixelIconButton` core component and applied semantic descriptions to its usages.
🎯 **Why:** Icon-only buttons lacked descriptions for screen readers, making the application inaccessible to users relying on assistive technology. This solves a major usability barrier for navigation and layer management.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Add layer", "Move layer up", "Navigate back", etc., instead of remaining silent or reading raw UI node information on these critical interactive elements.

---
*PR created automatically by Jules for task [8836568606183730854](https://jules.google.com/task/8836568606183730854) started by @srMarlins*