### PR TITLE
🎨 Palette: [UX improvement] Fix accessibility state for Switch and Button components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Proper Accessible State for Switches
+**Learning:** When building a custom switch component in Compose Multiplatform, using `clickable(role = Role.Switch)` is insufficient for proper accessibility because it only tells the screen reader the component is a switch, but not its current state.
+**Action:** Always use the `toggleable(value = checked, ...)` modifier instead. This correctly announces both the switch role AND its current on/off (boolean) state to assistive technologies.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelButton.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -87,6 +89,9 @@ fun PixelButton(
                 onClick = onClick,
                 role = androidx.compose.ui.semantics.Role.Button
             )
+            .semantics {
+                if (!enabled) disabled()
+            }
             .padding(top = pressDepth) // Reserve space for the "up" state
     ) {
         // Shadow / Bottom Layer

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +54,20 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                mod
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
🎨 Palette: [UX improvement] Fix accessibility state for Switch and Button components

💡 What: Replaced `.clickable` with `.toggleable` in `PixelSwitch` and added `disabled()` semantics to `PixelButton`.
🎯 Why: Screen readers could identify `PixelSwitch` as a switch, but could not read its "On/Off" state because `clickable` does not expose state. `PixelButton` disabled state wasn't explicitly announced if disabled.
📸 Before/After: Visuals remain identical, but screen reader tree correctly reflects toggle states and button interactability.
♿ Accessibility: Assistive tech now properly announces "Switch, Checked" or "Switch, Unchecked", and skips disabled buttons as non-interactive.

---
*PR created automatically by Jules for task [15554727726510476834](https://jules.google.com/task/15554727726510476834) started by @srMarlins*