### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix unauthorized data extraction and auto-correct caching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+
+## 2026-03-01 - [Critical] AllowBackup enabled in AndroidManifest.xml
+**Vulnerability:** The `android:allowBackup="true"` attribute was set in `android/app/src/main/AndroidManifest.xml`. This could allow unauthorized extraction of sensitive application data via ADB backups.
+**Learning:** The default for Android apps is to allow backups. For security, this must be explicitly disabled to prevent data leakage. Additionally, sensitive inputs like passwords should explicitly disable autocorrect caching to prevent the OS from storing them in its dictionary.
+**Prevention:** Set `android:allowBackup="false"` in `AndroidManifest.xml`. Ensure `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` is applied to `PixelTextField` usages that handle sensitive values.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name=".ChromaDMXApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.ChromaDMX">

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/ProvisioningScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -442,6 +444,7 @@ private fun ConfigFormContent(
                         label = { Text("Wi-Fi Password") },
                         modifier = Modifier.fillMaxWidth(),
                         visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                         singleLine = true
                     )
 

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/screen/settings/SettingsScreen.kt
@@ -743,6 +743,11 @@ private fun AgentSection(
                 } else {
                     androidx.compose.ui.text.input.PasswordVisualTransformation()
                 },
+                keyboardOptions = if (showKey || state.agentConfig.apiKey.isEmpty()) {
+                    KeyboardOptions.Default
+                } else {
+                    KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
 


### PR DESCRIPTION
🚨 Severity: CRITICAL/HIGH
💡 Vulnerability: 
1. `allowBackup` was set to true, allowing extraction of sensitive data via ADB.
2. Sensitive text fields (API Key, Wi-Fi password) lacked keyboard type restrictions, allowing the OS to cache inputs in its auto-correct dictionary.
🎯 Impact: Unauthorized actors could extract full app data via physical access (ADB) or access cached secrets from the device's keyboard dictionary.
🔧 Fix:
- Set `android:allowBackup="false"` in `AndroidManifest.xml`.
- Added `KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false)` to sensitive `PixelTextField` and `OutlinedTextField` usages.
✅ Verification: Ensure app compiles. Inspect manifest and UI components. Ensure no regression via test suite.

---
*PR created automatically by Jules for task [11128482817116584586](https://jules.google.com/task/11128482817116584586) started by @srMarlins*