### PR TITLE
🛡️ Sentinel: [security improvement] Disable Android Backup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name=".ChromaDMXApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.ChromaDMX">


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Android Backup Vulnerability

Disabled `android:allowBackup="true"` in the AndroidManifest.xml.

🚨 Severity: MEDIUM
💡 Vulnerability: The application allows backup via ADB when physical access is granted and USB debugging is enabled, making it susceptible to unauthorized data extraction.
🎯 Impact: An attacker could extract the app's data.
🔧 Fix: Set `android:allowBackup` to `false` in `AndroidManifest.xml` to prevent backup via ADB.
✅ Verification: Ran `grep` to verify the setting in `AndroidManifest.xml` and ran `lintDebug` and `testDebugUnitTest` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [2082261102161002558](https://jules.google.com/task/2082261102161002558) started by @srMarlins*