### PR TITLE
⚡ Bolt: [performance improvement] Optimize loop-invariant math and EffectParams allocation

### DIFF
--- a/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
+++ b/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/pregen/PreGenerationService.kt
@@ -112,7 +112,7 @@ class PreGenerationService(
         val layers = template.layers.map { layer ->
             EffectLayerConfig(
                 effectId = layer.effectId,
-                params = layer.params.entries.fold(EffectParams.EMPTY) { acc, (k, v) -> acc.with(k, v) },
+                params = EffectParams(layer.params),
                 blendMode = BlendMode.valueOf(layer.blendMode),
                 opacity = layer.opacity,
                 enabled = true

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/renderer/TopDownEditor.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/renderer/TopDownEditor.kt
@@ -320,9 +320,9 @@ fun TopDownEditor(
             }
 
             // Update screen positions for hit testing (transform-adjusted)
+            val pivotX = size.width / 2f
+            val pivotY = size.height / 2f
             fixtureScreenPositions = positions.map { pos ->
-                val pivotX = size.width / 2f
-                val pivotY = size.height / 2f
                 Offset(
                     (pos.x - pivotX) * zoom + pivotX + panOffset.x,
                     (pos.y - pivotY) * zoom + pivotY + panOffset.y,


### PR DESCRIPTION
💡 **What**:
- In `PreGenerationService.kt`, replaced the `layer.params.entries.fold(...)` map-copying mechanism with an $O(1)$ `EffectParams(layer.params)` direct constructor call.
- In `TopDownEditor.kt`, hoisted the loop-invariant `size.width / 2f` and `size.height / 2f` pivot calculations outside of the `fixtures.map` loop block inside the hit-testing hit-box updater.

🎯 **Why**:
- The `fold { with() }` construct copies the entire `Map` array every single iteration. Creating an $O(N)$ number of temporary maps inside batch loops spikes Garbage Collection (GC) pressure and negatively impacts performance during large scene generations.
- Re-calculating the center pivot dynamically for every individual DMX fixture during hit-testing screen position updates wastes CPU cycles. Extracting loop invariants drops raw arithmetic operations.

📊 **Impact**:
- Drops `EffectParams` map allocations in `PreGenerationService` from $O(N^2)$ map-copies to $O(1)$ map references.
- Lowers main-thread rendering CPU usage in the TopDownEditor canvas interaction loops.

🔬 **Measurement**:
Verified that `PreGenerationService` functionality correctly generates scenes using the new map reference, and the tests in `:shared:agent:testAndroidHostTest` and `:shared:lint` pass without issue.

---
*PR created automatically by Jules for task [8943171034881279969](https://jules.google.com/task/8943171034881279969) started by @srMarlins*