### PR TITLE
⚡ Bolt: [performance improvement] Replace chained filter.map with mapNotNull to reduce allocations

### DIFF
--- a/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/controller/RealStateController.kt
+++ b/shared/agent/src/commonMain/kotlin/com/chromadmx/agent/controller/RealStateController.kt
@@ -31,8 +31,7 @@ class RealStateController(
             fixtureCount = fixturesProvider().size,
             fps = 0f, // TODO: Wire frame timing measurement from engine
             effectIds = stack.layers
-                .filter { it.enabled }
-                .map { it.effect.id }
+                .mapNotNull { if (it.enabled) it.effect.id else null }
         )
     }
 

--- a/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
+++ b/shared/vision/src/commonMain/kotlin/com/chromadmx/vision/detection/BlobDetector.kt
@@ -63,16 +63,19 @@ class BlobDetector(
 
         // Convert accumulators to DetectedBlob, filter by min size
         return components.values
-            .filter { it.count >= minBlobSize }
-            .map { acc ->
-                DetectedBlob(
-                    centroid = Coord2D(
-                        x = acc.weightedSumX / acc.totalBrightness,
-                        y = acc.weightedSumY / acc.totalBrightness
-                    ),
-                    pixelCount = acc.count,
-                    totalBrightness = acc.totalBrightness
-                )
+            .mapNotNull { acc ->
+                if (acc.count >= minBlobSize) {
+                    DetectedBlob(
+                        centroid = Coord2D(
+                            x = acc.weightedSumX / acc.totalBrightness,
+                            y = acc.weightedSumY / acc.totalBrightness
+                        ),
+                        pixelCount = acc.count,
+                        totalBrightness = acc.totalBrightness
+                    )
+                } else {
+                    null
+                }
             }
             .sortedByDescending { it.totalBrightness }
     }


### PR DESCRIPTION
💡 What: Replaced `.filter {}.map {}` chains with `.mapNotNull {}` in `BlobDetector.kt` and `RealStateController.kt`.
🎯 Why: Chaining `filter` and `map` creates temporary intermediate collections. In high-frequency paths like vision processing, this causes unnecessary garbage collection pressure.
📊 Impact: Reduces intermediate list allocations to zero, lowering memory overhead and improving execution speed.
🔬 Measurement: Verified by running test suites for `vision` and `agent` modules successfully on Android Host.

---
*PR created automatically by Jules for task [787009315160722323](https://jules.google.com/task/787009315160722323) started by @srMarlins*