### PR TITLE
🎨 Palette: [UX improvement] Improve PixelSwitch accessibility using toggleable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Compose Switch Accessibility
+
+**Learning:** When building custom Switch components in Compose Multiplatform, using `Modifier.clickable(role = Role.Switch)` is insufficient because it does not announce the switch's `checked` (on/off) state to screen readers like TalkBack or VoiceOver. Furthermore, if the component supports a read-only state (e.g., `onCheckedChange` is null), omitting interactivity entirely will drop the `Role.Switch` semantics, making it appear as a generic text or box.
+
+**Action:** Always use `Modifier.toggleable` instead of `clickable` for switches. If the switch needs to support a read-only state (nullable callback), wrap the `toggleable` modifier in a conditional `.let` block, and explicitly provide fallback semantics (`Modifier.semantics { role = Role.Switch; toggleableState = ... }`) when the callback is null to ensure screen readers always announce its role and state.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -17,6 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -54,13 +58,23 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { modifier ->
+            if (onCheckedChange != null) {
+                modifier.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                modifier.semantics {
+                    role = Role.Switch
+                    toggleableState = if (checked) ToggleableState.On else ToggleableState.Off
+                }
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 What: Replaced the `clickable(role = Role.Switch)` modifier with `toggleable(value = checked)` on the custom `PixelSwitch` component. If the switch is read-only (`onCheckedChange` is null), fallback semantics are applied to ensure it still announces its role and state.

🎯 Why: To fix an accessibility issue where screen readers would announce the element as a switch but would not read its "on" or "off" status, confusing users relying on assistive technology.

📸 Before/After: Visuals are identical, but semantic tree now includes `ToggleableState`.

♿ Accessibility: Ensures custom switch fully implements the Compose `Toggleable` contract for TalkBack/VoiceOver support.

---
*PR created automatically by Jules for task [7083467657501939237](https://jules.google.com/task/7083467657501939237) started by @srMarlins*