### PR TITLE
⚡ Bolt: [performance improvement] Optimize DmxBridge high-frequency rendering loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
-**Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
-**Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2025-02-23 - Optimize DmxBridge profile lookups
+**Learning:** In a high-frequency rendering loop (like 40Hz to 60Hz), doing O(N) profile map lookups inside a per-fixture loop causes severe performance overhead. Additionally, repeated object instantiations like `Color` and iterator allocations via standard `for (item in list)` incur constant GC pressure.
+**Action:** When working on code that executes every frame for many objects, prefer pre-computing fixed metadata mappings in parallel arrays and using manual index loops (`for (i in array.indices)`) instead of iterator-generating `for (item in list)` structures. Coerce primitive values locally instead of using object-returning methods like `color.clamped()`.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
@@ -1,6 +1,7 @@
 package com.chromadmx.engine.bridge
 
 import com.chromadmx.core.model.BuiltInProfiles
+import com.chromadmx.core.model.Channel
 import com.chromadmx.core.model.ChannelType
 import com.chromadmx.core.model.Color
 import com.chromadmx.core.model.Fixture3D
@@ -22,6 +23,26 @@ class DmxBridge(
     private val fixtures: List<Fixture3D>,
     private val profiles: Map<String, FixtureProfile> = emptyMap()
 ) {
+    // Pre-resolved metadata for faster rendering loops
+    private val resolvedProfiles: Array<FixtureProfile?> = Array(fixtures.size) { i ->
+        val profileId = fixtures[i].fixture.profileId
+        profiles[profileId] ?: BuiltInProfiles.findById(profileId)
+    }
+
+    // Convert channel lists to arrays to prevent iterator allocation during loops
+    private val profileChannels: Array<Array<Channel>?> = Array(fixtures.size) { i ->
+        resolvedProfiles[i]?.channels?.toTypedArray()
+    }
+
+    private val resolvedHasRgb: BooleanArray = BooleanArray(fixtures.size) { i ->
+        resolvedProfiles[i]?.hasRgb == true
+    }
+    private val universeIds: IntArray = IntArray(fixtures.size) { i ->
+        fixtures[i].fixture.universeId
+    }
+    private val channelStarts: IntArray = IntArray(fixtures.size) { i ->
+        fixtures[i].fixture.channelStart
+    }
     /**
      * Convert an array of per-fixture colors into per-universe DMX data.
      *
@@ -34,17 +55,16 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
-            val color = colors.getOrElse(i) { Color.BLACK }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val color = if (i < colors.size) colors[i] else Color.BLACK
+            val data = universes.getOrPut(universeIds[i]) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
-            if (profile != null && profile.hasRgb) {
-                writeProfileChannels(data, fixture.channelStart, profile, color)
+            val channels = profileChannels[i]
+            if (profile != null && channels != null && resolvedHasRgb[i]) {
+                writeProfileChannels(data, channelStarts[i], profile, channels, color)
             } else {
                 // Fallback: write as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, color)
+                writeSimpleRgb(data, channelStarts[i], color)
             }
         }
 
@@ -65,17 +85,16 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
-            val output = outputs.getOrElse(i) { FixtureOutput.DEFAULT }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val output = if (i < outputs.size) outputs[i] else FixtureOutput.DEFAULT
+            val data = universes.getOrPut(universeIds[i]) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
-            if (profile != null) {
-                writeProfileChannelsWithOutput(data, fixture.channelStart, profile, output)
+            val channels = profileChannels[i]
+            if (profile != null && channels != null) {
+                writeProfileChannelsWithOutput(data, channelStarts[i], profile, channels, output)
             } else {
                 // Fallback: write color as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, output.color)
+                writeSimpleRgb(data, channelStarts[i], output.color)
             }
         }
 
@@ -86,6 +105,7 @@ class DmxBridge(
         data: ByteArray,
         channelStart: Int,
         profile: FixtureProfile,
+        channels: Array<Channel>,
         color: Color
     ) {
         // Optimization: bypass clamped() to prevent allocating a Color object per fixture per frame
@@ -96,7 +116,9 @@ class DmxBridge(
         val hasDimmer = profile.channelByType(ChannelType.DIMMER) != null
         val brightness = maxOf(cr, cg, cb)
 
-        for (channel in profile.channels) {
+        // Optimization: Iterate directly over the pre-calculated channels array.
+        for (i in channels.indices) {
+            val channel = channels[i]
             val addr = channelStart + channel.offset
             if (addr < 0 || addr >= 512) continue
 
@@ -131,6 +153,7 @@ class DmxBridge(
         data: ByteArray,
         channelStart: Int,
         profile: FixtureProfile,
+        channels: Array<Channel>,
         output: FixtureOutput
     ) {
         // Optimization: bypass clamped() to prevent allocating a Color object per fixture per frame
@@ -141,7 +164,9 @@ class DmxBridge(
         val hasDimmer = profile.channelByType(ChannelType.DIMMER) != null
         val brightness = maxOf(cr, cg, cb)
 
-        for (channel in profile.channels) {
+        // Optimization: Iterate directly over the pre-calculated channels array.
+        for (i in channels.indices) {
+            val channel = channels[i]
             val addr = channelStart + channel.offset
             if (addr < 0 || addr >= 512) continue
 


### PR DESCRIPTION
💡 What: Pre-computes FixtureProfile lookups, property queries (hasRgb, universeId, channelStart), and converts channel lists to typed Arrays in the constructor. Updates the hot rendering loop to use index-based `for (i in array.indices)` iterations instead of `for (item in list)` and eliminates `List.getOrElse` with lambda allocations.
🎯 Why: In the high-frequency rendering loop (40Hz-60Hz), the DMX data generator executes over every fixture. Previously it was performing O(N) map lookups, creating lambda expressions, and allocating `Iterator` objects on every loop pass, incurring massive GC pressure and CPU overhead.
📊 Impact: Completely eliminates O(N) profile map lookups and `Iterator` generation within the per-frame per-fixture render loop. Significantly reduces GC pressure and speeds up DMX data generation in `EffectEngine`.
🔬 Measurement: Run a stress test (like 100+ fixtures with high-density profiles) on a mobile device and profile the memory allocation / GC pause times in Android Studio Profiler, focusing on the `DmxBridge.convert` operations.

---
*PR created automatically by Jules for task [16929883630472687658](https://jules.google.com/task/16929883630472687658) started by @srMarlins*