### PR TITLE
⚡ Bolt: [performance improvement] Optimize DmxBridge loops with parallel arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2024-05-15 - Fast Array Lookups in Render Loops
+**Learning:** In 60FPS render loops, map lookups (even optimized ones) inside nested iterations (like `profiles[fixture.profileId]` per fixture, per frame) can cause significant CPU overhead and degrade performance.
+**Action:** When working in critical render paths (like `DmxBridge` or `EffectEngine`), pre-resolve map lookups and metadata into parallel primitive arrays (`IntArray`, `Array`) during initialization. This changes O(N) lookup complexity to O(1) direct array access per iteration.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
@@ -22,6 +22,14 @@ class DmxBridge(
     private val fixtures: List<Fixture3D>,
     private val profiles: Map<String, FixtureProfile> = emptyMap()
 ) {
+    // Pre-resolved metadata for fast lookups in per-frame loops
+    private val resolvedProfiles = Array(fixtures.size) { i ->
+        val profileId = fixtures[i].fixture.profileId
+        profiles[profileId] ?: BuiltInProfiles.findById(profileId)
+    }
+    private val universeIds = IntArray(fixtures.size) { i -> fixtures[i].fixture.universeId }
+    private val channelStarts = IntArray(fixtures.size) { i -> fixtures[i].fixture.channelStart }
+
     /**
      * Convert an array of per-fixture colors into per-universe DMX data.
      *
@@ -34,17 +42,15 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
             val color = colors.getOrElse(i) { Color.BLACK }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val data = universes.getOrPut(universeIds[i]) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
             if (profile != null && profile.hasRgb) {
-                writeProfileChannels(data, fixture.channelStart, profile, color)
+                writeProfileChannels(data, channelStarts[i], profile, color)
             } else {
                 // Fallback: write as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, color)
+                writeSimpleRgb(data, channelStarts[i], color)
             }
         }
 
@@ -65,17 +71,15 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
             val output = outputs.getOrElse(i) { FixtureOutput.DEFAULT }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val data = universes.getOrPut(universeIds[i]) { ByteArray(512) }
+            val profile = resolvedProfiles[i]
 
             if (profile != null) {
-                writeProfileChannelsWithOutput(data, fixture.channelStart, profile, output)
+                writeProfileChannelsWithOutput(data, channelStarts[i], profile, output)
             } else {
                 // Fallback: write color as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, output.color)
+                writeSimpleRgb(data, channelStarts[i], output.color)
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-resolve fixture profiles, universe IDs, and channel starts into parallel arrays in the `DmxBridge` constructor.
🎯 Why: `profiles[fixture.profileId]` map lookups and nested property accesses were being executed on every fixture for every frame inside a 60FPS loop, causing unnecessary CPU overhead.
📊 Impact: Changes O(N) lookup complexity to O(1) direct array access, reducing CPU usage during DMX conversion.
🔬 Measurement: Verify stable 60FPS during complex effects with high fixture counts using the engine's internal FPS metric. Tested compilation and unit tests.

---
*PR created automatically by Jules for task [3363713408537514768](https://jules.google.com/task/3363713408537514768) started by @srMarlins*