### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix ADB Backup vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+## 2024-05-24 - [Disable ADB Backup]
+**Vulnerability:** The Android App `AndroidManifest.xml` had `android:allowBackup="true"`.
+**Learning:** This exposes sensitive app data to unauthorized extraction via `adb backup` or cloud backups.
+**Prevention:** Always ensure `android:allowBackup="false"` is set in `AndroidManifest.xml` unless explicit granular backup rules are configured.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name=".ChromaDMXApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.ChromaDMX">


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `android:allowBackup="true"` was enabled in the AndroidManifest.xml.
🎯 **Impact:** This misconfiguration exposes potentially sensitive application data (such as local databases, preferences, or authentication tokens) to unauthorized extraction via `adb backup` or cloud backups.
🔧 **Fix:** Set `android:allowBackup="false"` in the `AndroidManifest.xml` to prevent this data extraction.
✅ **Verification:** Ran `./gradlew :android:app:lintDebug` and `./gradlew :android:app:testDebugUnitTest` to ensure the module is free of errors and tests pass. Tested the build and verified the `AndroidManifest.xml` output.

---
*PR created automatically by Jules for task [16932590152133045602](https://jules.google.com/task/16932590152133045602) started by @srMarlins*