### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility semantics of PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Accessibility of Custom Switch Components
+**Learning:** For custom switch components in Compose Multiplatform, using `.clickable(role = Role.Switch)` is insufficient as it only announces the role but not the true/false boolean state. The component must use `.toggleable(value = checked)` to accurately announce both its role and state to screen readers. If the component needs to be selectively disabled/read-only without a state change callback, `.let { ... }` can be used to conditionally apply `toggleable` only when the callback is not null.
+**Action:** When building interactive binary-state components (switches, checkboxes) in Compose, always prefer the `toggleable` modifier over `clickable` with a role.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -17,6 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations
@@ -54,13 +58,23 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let { mod ->
+            if (onCheckedChange != null) {
+                mod.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                mod.semantics {
+                    role = Role.Switch
+                    toggleableState = ToggleableState(checked)
+                }
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(


### PR DESCRIPTION
💡 What: The `clickable` modifier in `PixelSwitch.kt` was replaced with the `toggleable` modifier, and for read-only switches, explicit `toggleableState` semantics were applied.
🎯 Why: The original implementation only announced the component as a switch but did not announce its true/false state to screen readers, making it inaccessible for visually impaired users to understand its current state.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen readers will now correctly announce both the role (Switch) and its boolean state.

---
*PR created automatically by Jules for task [16767565573846277161](https://jules.google.com/task/16767565573846277161) started by @srMarlins*