### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix ADB backup vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys and sensitive tokens in `SettingsScreen.kt` were manually mutated into strings composed of bullet characters (`\u2022`) to mask them. The underlying logic was vulnerable because it replaced the actual state value and required complicated reconstruction logic on the first keystroke, creating risks of secrets leaking in state updates, logging, or accidentally being saved as dots into storage or the API config.
 **Learning:** For masking secrets like API keys in Compose UI state, custom text fields must support Compose's `VisualTransformation` parameter so that the view can mask the output securely without ever changing the underlying raw string state value.
 **Prevention:** When building custom TextFields (e.g., `PixelTextField`), always expose the `visualTransformation` parameter and pass it to the internal `BasicTextField`. Always use `PasswordVisualTransformation()` to mask sensitive values instead of manipulating strings.
+## 2026-05-03 - Prevent ADB Backup Extraction
+**Vulnerability:** Android apps with `android:allowBackup="true"` (default) allow attackers with physical access or USB debugging to extract sensitive local app data.
+**Learning:** This is a common and often overlooked configuration in Android manifests that poses a medium-security risk for apps handling sensitive data.
+**Prevention:** Ensure `android:allowBackup="false"` is explicitly set in the `AndroidManifest.xml` to disable backup extraction unless explicitly required for the app's functionality.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name=".ChromaDMXApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.ChromaDMX">


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Android app was configured to allow data backups (`android:allowBackup="true"`), which could allow an attacker with physical access or USB debugging enabled to extract sensitive local app data.
🎯 Impact: Unauthorized access to locally stored app data, databases, and preferences.
🔧 Fix: Set `android:allowBackup="false"` in the `AndroidManifest.xml` to prevent backup extraction.
✅ Verification: Ran `./gradlew :android:app:lintDebug` and `./gradlew :android:app:testDebugUnitTest` to verify no compilation issues or test failures were introduced.

---
*PR created automatically by Jules for task [12935163402989458243](https://jules.google.com/task/12935163402989458243) started by @srMarlins*