### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-03-01 - Avoid Intermediate Color Allocations in Hot Paths
 **Learning:** In the DMX engine's rendering hot path (`EffectStack`), even simple operations like `Color * float` or `.clamped()` can create thousands of intermediate `Color` objects per frame, leading to GC pauses and dropped frames.
 **Action:** When working in the inner loop (e.g., `evaluate()` methods), bypass operator overloads that allocate new objects if the inputs are already bounded, and use direct `Color` instantiation with pre-multiplied/clamped values.
+## 2025-03-02 - DMX Bridge Resolution O(N) lookup overhead elimination
+**Learning:** `DmxBridge` evaluated metadata repeatedly per frame in `convert()` / `convertOutputs()`, fetching profiles from maps and properties within a hot path. High-frequency rendering causes this redundant check overhead to accumulate.
+**Action:** Pre-resolve fixture metadata (profile, channel starts, universe info) into flat indexed arrays during `DmxBridge` initialization. This enables simple array O(1) lookups during the main high-frequency loop and eliminates hash map accesses.

--- a/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
+++ b/shared/engine/src/commonMain/kotlin/com/chromadmx/engine/bridge/DmxBridge.kt
@@ -22,6 +22,23 @@ class DmxBridge(
     private val fixtures: List<Fixture3D>,
     private val profiles: Map<String, FixtureProfile> = emptyMap()
 ) {
+    // Pre-resolved metadata arrays for O(1) access during high-frequency conversion loops
+    private val resolvedUniverseIds = IntArray(fixtures.size)
+    private val resolvedChannelStarts = IntArray(fixtures.size)
+    private val resolvedProfiles = arrayOfNulls<FixtureProfile>(fixtures.size)
+    private val resolvedHasRgb = BooleanArray(fixtures.size)
+
+    init {
+        for (i in fixtures.indices) {
+            val fixture = fixtures[i].fixture
+            resolvedUniverseIds[i] = fixture.universeId
+            resolvedChannelStarts[i] = fixture.channelStart
+            val profile = profiles[fixture.profileId] ?: BuiltInProfiles.findById(fixture.profileId)
+            resolvedProfiles[i] = profile
+            resolvedHasRgb[i] = profile?.hasRgb == true
+        }
+    }
+
     /**
      * Convert an array of per-fixture colors into per-universe DMX data.
      *
@@ -34,17 +51,19 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
-            val color = colors.getOrElse(i) { Color.BLACK }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val universeId = resolvedUniverseIds[i]
+            val channelStart = resolvedChannelStarts[i]
+            val profile = resolvedProfiles[i]
+            val hasRgb = resolvedHasRgb[i]
 
-            if (profile != null && profile.hasRgb) {
-                writeProfileChannels(data, fixture.channelStart, profile, color)
+            val color = colors.getOrElse(i) { Color.BLACK }
+            val data = universes.getOrPut(universeId) { ByteArray(512) }
+
+            if (profile != null && hasRgb) {
+                writeProfileChannels(data, channelStart, profile, color)
             } else {
                 // Fallback: write as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, color)
+                writeSimpleRgb(data, channelStart, color)
             }
         }
 
@@ -65,17 +84,18 @@ class DmxBridge(
         val universes = mutableMapOf<Int, ByteArray>()
 
         for (i in fixtures.indices) {
-            val fixture = fixtures[i].fixture
+            val universeId = resolvedUniverseIds[i]
+            val channelStart = resolvedChannelStarts[i]
+            val profile = resolvedProfiles[i]
+
             val output = outputs.getOrElse(i) { FixtureOutput.DEFAULT }
-            val data = universes.getOrPut(fixture.universeId) { ByteArray(512) }
-            val profile = profiles[fixture.profileId]
-                ?: BuiltInProfiles.findById(fixture.profileId)
+            val data = universes.getOrPut(universeId) { ByteArray(512) }
 
             if (profile != null) {
-                writeProfileChannelsWithOutput(data, fixture.channelStart, profile, output)
+                writeProfileChannelsWithOutput(data, channelStart, profile, output)
             } else {
                 // Fallback: write color as simple 3-channel RGB
-                writeSimpleRgb(data, fixture.channelStart, output.color)
+                writeSimpleRgb(data, channelStart, output.color)
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-resolve DmxBridge metadata into arrays to avoid per-frame map lookups and nested property access.
🎯 Why: DmxBridge previously iterated fixtures in a hot path, repeatedly making O(N) map lookups and property accesses per fixture per frame.
📊 Impact: Reduced per-frame processing overhead by utilizing O(1) array lookups.
🔬 Measurement: Verify with ./gradlew :shared:engine:testAndroidHostTest

---
*PR created automatically by Jules for task [15023679125965028072](https://jules.google.com/task/15023679125965028072) started by @srMarlins*