### PR TITLE
🎨 Palette: [UX improvement] Fix Screen Reader State for PixelSwitch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-04 - PixelSwitch Accessibility
+**Learning:** In Compose Multiplatform, using `clickable(role = Role.Switch)` on a custom switch component only announces the role but fails to communicate the actual on/off boolean state to screen readers.
+**Action:** Replace `clickable` with `toggleable(value = checked, ...)` which correctly announces both the role and state. For components where the callback might be null, conditionally apply `toggleable` using a `.let` block so it correctly remains non-interactive when no callback is provided.

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -4,7 +4,10 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
@@ -54,13 +57,23 @@ fun PixelSwitch(
     // Track uses chamfered shape; glowing when checked, standard when unchecked
     val trackModifier = modifier
         .size(width = trackWidth, height = trackHeight)
-        .clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            enabled = enabled,
-            onClick = { onCheckedChange?.invoke(!checked) },
-            role = Role.Switch
-        )
+        .let {
+            if (onCheckedChange != null) {
+                it.toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                )
+            } else {
+                it.semantics {
+                    role = Role.Switch
+                    toggleableState = ToggleableState(checked)
+                }
+            }
+        }
         .let { mod ->
             if (checked && enabled) {
                 mod.pixelBorderGlowing(

--- a/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
+++ b/shared/src/commonMain/kotlin/com/chromadmx/ui/components/PixelSwitch.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.chromadmx.ui.theme.ChromaAnimations


### PR DESCRIPTION
💡 What: Replaced `clickable` with `toggleable` on the `PixelSwitch` component. Conditionally applied the modifier using a `.let` block so it correctly remains non-interactive when no callback is provided.
🎯 Why: In Compose Multiplatform, using `clickable(role = Role.Switch)` only announces the role but fails to communicate the actual on/off boolean state to screen readers, making it confusing for visually impaired users.
📸 Before/After: Accessibility text went from "Switch" to "Switch, Checked/Unchecked". (No visual changes)
♿ Accessibility: Screen readers will now announce the current toggle state correctly.

---
*PR created automatically by Jules for task [15669325784150412752](https://jules.google.com/task/15669325784150412752) started by @srMarlins*